### PR TITLE
Sanitize shape

### DIFF
--- a/proximal/lin_ops/lin_op.py
+++ b/proximal/lin_ops/lin_op.py
@@ -30,7 +30,7 @@ class LinOp(object):
         # Convert scalars to tuples.
         if np.isscalar(shape):
             shape = (shape,)
-        return shape
+        return tuple(shape)
 
     def variables(self):
         """Return the list of variables used in the LinOp.

--- a/proximal/tests/test_lin_ops.py
+++ b/proximal/tests/test_lin_ops.py
@@ -14,6 +14,17 @@ import cv2
 
 class TestLinOps(BaseTest):
 
+    def test_variable(self):
+        """Test Variable"""
+        var = Variable(3)
+        assert var.shape == (3,)
+        var = Variable((3,))
+        assert var.shape == (3,)
+        var = Variable((3, 2))
+        assert var.shape == (3, 2)
+        var = Variable([3, 2])
+        assert var.shape == (3, 2)
+
     def test_subsample(self):
         """Test subsample lin op.
         """
@@ -341,7 +352,7 @@ class TestLinOps(BaseTest):
         W = np.arange(10)
         W = np.reshape(W, (2,5))
         fn = mul_elemwise(W, x)
-        fn = fn + x + W 
+        fn = fn + x + W
         self.assertEquals(len(fn.input_nodes), 3)
         fn = CompGraph(fn)
         x = W.copy()


### PR DESCRIPTION
Add sanitation  to shape as given to `LinOp`, this fixes later issues caused by code such as

```python
>>> [10, 10] == (10, 10)
False
```