### PR TITLE
Correct the timing of dual residual evaluation in ADMM.

### DIFF
--- a/proximal/algorithms/admm.py
+++ b/proximal/algorithms/admm.py
@@ -105,6 +105,7 @@ def solve(psi_fns, omega_fns, rho=1.0,
         if i % conv_check == 0:
             r = Kv - z
             K.adjoint(u, KTu)
+            K.adjoint(rho * (z - z_prev), s)
             eps_pri = np.sqrt(K.output_size) * eps_abs + eps_rel * \
                 max([np.linalg.norm(Kv), np.linalg.norm(z)])
             eps_dual = np.sqrt(K.input_size) * eps_abs + eps_rel * np.linalg.norm(KTu) * rho
@@ -125,7 +126,6 @@ def solve(psi_fns, omega_fns, rho=1.0,
                 objstr = ", obj_val = %02.03e" % sum([fn.value for fn in prox_fns])
 
             # Evaluate metric potentially
-            K.adjoint(rho * (z - z_prev), s)
             metstr = '' if metric is None else ", {}".format(metric.message(v))
             print("iter %d: ||r||_2 = %.3f, eps_pri = %.3f, ||s||_2 = %.3f, eps_dual = %.3f%s%s" % (
                 i, np.linalg.norm(r), eps_pri, np.linalg.norm(s), eps_dual, objstr, metstr))


### PR DESCRIPTION
I had a mistake on my previous PR.
The evaluation timing of dual residual `s` was misplaced.