### PR TITLE
Verify elementwise norm-p against cvx implementation

### DIFF
--- a/proximal/tests/base_test.py
+++ b/proximal/tests/base_test.py
@@ -2,6 +2,7 @@
 import numpy as np
 from typing import Union
 from numbers import Real
+from pytest import approx
 
 
 class BaseTest:
@@ -17,30 +18,24 @@ class BaseTest:
         if type(b) is list:
             b = np.array(a)
 
-        vmax = np.max(
-            (np.linalg.norm(a.ravel(),
-                            np.Inf), np.linalg.norm(b.ravel(), np.Inf)))
+        assert a.shape == b.shape
 
-        rel_diff = np.linalg.norm(a.ravel() - b.ravel(), np.Inf)
+        norm_infinity_b = np.linalg.norm(b.ravel(), np.Inf)
 
-        if vmax == 0:
-            assert rel_diff < eps
+        if norm_infinity_b == 0:
+            # b is a zero matrix / vector
+            assert a == approx(b, abs=eps)
             return
 
-        rel_diff /= vmax
-
-        assert rel_diff < eps
+        assert a == approx(b, abs=norm_infinity_b * eps)
 
     def assertAlmostEqual(self, a: Real, b: Real, places=4, eps=1e-5):
         ''' Make sure that max absolute difference is smaller than a threshold '''
-        delta = abs(a - b)
-        vmax = max(abs(a), abs(b))
-        if vmax == 0:
-            assert delta < eps
+        if b == 0:
+            assert a == approx(b, abs=eps)
             return
 
-        rel_diff = delta / vmax
-        assert rel_diff < eps
+        assert a == approx(b, rel=eps)
 
     def assertEqual(self, a, b):
         self.assertEquals(a, b)

--- a/proximal/tests/test_lin_ops.py
+++ b/proximal/tests/test_lin_ops.py
@@ -74,7 +74,7 @@ class TestLinOps(BaseTest):
         y_val = np.reshape(np.arange(6) * 1.0 - 5, x.shape)
         out = np.zeros(fn.shape)
         fn.forward([x_val, y_val], [out])
-        self.assertItemsAlmostEqual(out, 2 * np.arange(6) - 5)
+        self.assertItemsAlmostEqual(out.ravel(), 2 * np.arange(6) - 5)
 
         # Adjoint.
         x_val = np.reshape(np.arange(6) * 1.0, x.shape)
@@ -89,7 +89,7 @@ class TestLinOps(BaseTest):
         x_val = np.reshape(np.arange(6) * 1.0, x.shape)
         y_val = np.reshape(np.arange(6) * 1.0 - 5, x.shape)
         fn = sum([x_val, y_val])
-        self.assertItemsAlmostEqual(fn.value, 2 * np.arange(6) - 5)
+        self.assertItemsAlmostEqual(fn.value.ravel(), 2 * np.arange(6) - 5)
 
         # Diagonal form.
         x = Variable(5)
@@ -308,7 +308,7 @@ class TestLinOps(BaseTest):
         x = W.copy()
         out = np.zeros(x.shape).flatten()
         fn.adjoint(x, out)
-        self.assertItemsAlmostEqual(out, -2 * W * W)
+        self.assertItemsAlmostEqual(out, (-2 * W * W).ravel())
 
         # Forward.
         var = Variable((2, 5))
@@ -325,7 +325,7 @@ class TestLinOps(BaseTest):
         x = W.copy()
         out = np.zeros(x.shape).flatten()
         fn.adjoint(x, out)
-        self.assertItemsAlmostEqual(out, W * W / 2.)
+        self.assertItemsAlmostEqual(out, (W * W / 2.).ravel())
 
         # Dividing by a scalar.
         # Forward.
@@ -357,7 +357,7 @@ class TestLinOps(BaseTest):
         x = W.copy()
         out = np.zeros(x.shape).flatten()
         fn.adjoint(x, out)
-        self.assertItemsAlmostEqual(out, W * W + 2 * W)
+        self.assertItemsAlmostEqual(out, (W * W + 2 * W).ravel())
 
         # Adding in a constant.
         # CompGraph should ignore the constant.
@@ -391,7 +391,7 @@ class TestLinOps(BaseTest):
         x = W.copy()
         out = np.zeros(x.shape).flatten()
         fn.adjoint(x, out)
-        self.assertItemsAlmostEqual(out, W * W + 2 * W)
+        self.assertItemsAlmostEqual(out, (W * W + 2 * W).ravel())
 
     def test_mask_halide(self):
         """Test mask lin op in halide.


### PR DESCRIPTION
Previously on tag `v0.1.7`, unit test of proximal norm-1 implementation
against cvxpy's counterpart failed because of the subtle difference
between 'elementwise' norm and the 'vector' norm.

Citation: https://cvxpy.readthedocs.io/en/latest/tutorial/functions/#clarifications

This patch updates the CVX function calls to elementwise norms
- `cvx.pnorm(x, 1)`, or
- `cvx.pnorm(x, 2)`,
so that both proximal and cvx refers to the same mathematical
definitions.

Following this code update, all test cases in `test_algs.py` validates
on the TravisCI server.

As suggested in #15 , the long term solution is to verify all `proximal` algorithms with analytic solutions, such that the test will be immune to any future CVXPY API updates.

Linked issues:
- #15 
- #52 