### PR TITLE
Upgrade to Halide 10 with CUDA autoscheduler

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: [edited, submitted]
 
 jobs:
   build:
@@ -26,9 +26,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install build-essential
-        sudo apt-get install ninja-build
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest ninja
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
 virtualenv:
   system_site_packages: true
 script:
+- bash continuous_integration/test_mesonbuild.sh
 - bash continuous_integration/test_script.sh
 notifications:
   email: false

--- a/continuous_integration/test_mesonbuild.sh
+++ b/continuous_integration/test_mesonbuild.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+cd proximal/halide
+meson build
+ninja -C build

--- a/proximal/halide/halide.py
+++ b/proximal/halide/halide.py
@@ -44,7 +44,7 @@ class Halide(object):
 
         # Save arguments
         self.func = func
-        self.module_name = 'lib{}'.format(func)
+        self.module_name = func
         self.builddir = builddir
         self.recompile = recompile
         self.reconfigure = reconfigure
@@ -86,7 +86,7 @@ class Halide(object):
         ''' Generate the new code (exits on fail) '''
 
         subprocess.check_call(
-            ['ninja', '-C', self.builddir, '{}.so'.format(self.module_name)])
+            ['ninja', '-C', self.builddir, self.module_name])
 
     def run(self, *args):
         """ Execute Halide code that was compiled before. """

--- a/proximal/halide/interface/A_conv.cpp
+++ b/proximal/halide/interface/A_conv.cpp
@@ -17,6 +17,6 @@ int A_conv_glue(const array_float_t input, const array_float_t K,
 
 } // proximal
 
-PYBIND11_MODULE(libA_conv, m) {
+PYBIND11_MODULE(A_conv, m) {
     m.def("run", &proximal::A_conv_glue, "Apply 2D convolution");
 }

--- a/proximal/halide/interface/A_conv.cpp
+++ b/proximal/halide/interface/A_conv.cpp
@@ -8,9 +8,11 @@ int A_conv_glue(const array_float_t input, const array_float_t K,
 
         auto input_buf = getHalideBuffer<3>(input);
         auto K_buf = getHalideBuffer<3>(K);
-        auto output_buf = getHalideBuffer<3>(output);
+        auto output_buf = getHalideBuffer<3>(output, true);
 
-        return convImg(input_buf, K_buf, output_buf);
+        const int success = convImg(input_buf, K_buf, output_buf);
+        output_buf.copy_to_host();
+        return success;
     }
 
 } // proximal

--- a/proximal/halide/interface/A_grad.cpp
+++ b/proximal/halide/interface/A_grad.cpp
@@ -15,6 +15,6 @@ A_grad_glue(const array_float_t input, array_float_t output) {
 
 }  // namespace proximal
 
-PYBIND11_MODULE(libA_grad, m) {
+PYBIND11_MODULE(A_grad, m) {
     m.def("run", &proximal::A_grad_glue, "Compute adjoint of gradient");
 }

--- a/proximal/halide/interface/A_grad.cpp
+++ b/proximal/halide/interface/A_grad.cpp
@@ -6,9 +6,11 @@ namespace proximal {
 int
 A_grad_glue(const array_float_t input, array_float_t output) {
     auto input_buf = getHalideBuffer<3>(input);
-    auto output_buf = getHalideBuffer<4>(output);
+    auto output_buf = getHalideBuffer<4>(output, true);
 
-    return gradImg(input_buf, output_buf);
+    const int success = gradImg(input_buf, output_buf);
+    output_buf.copy_to_host();
+    return success;
 }
 
 }  // namespace proximal

--- a/proximal/halide/interface/A_mask.cpp
+++ b/proximal/halide/interface/A_mask.cpp
@@ -8,9 +8,11 @@ int A_mask(const array_float_t input, const array_float_t mask,
 
         auto input_buf = getHalideBuffer<3>(input);
         auto mask_buf = getHalideBuffer<3>(mask);
-        auto output_buf = getHalideBuffer<3>(output);
+        auto output_buf = getHalideBuffer<3>(output, true);
 
-        return WImg(input_buf, mask_buf, output_buf);
+        const bool success = WImg(input_buf, mask_buf, output_buf);
+        output_buf.copy_to_host();
+        return success;
     }
 
 } // proximal

--- a/proximal/halide/interface/A_mask.cpp
+++ b/proximal/halide/interface/A_mask.cpp
@@ -17,6 +17,6 @@ int A_mask(const array_float_t input, const array_float_t mask,
 
 } // proximal
 
-PYBIND11_MODULE(libA_mask, m) {
+PYBIND11_MODULE(A_mask, m) {
     m.def("run", &proximal::A_mask, "Apply elementwise multiplication");
 }

--- a/proximal/halide/interface/A_warp.cpp
+++ b/proximal/halide/interface/A_warp.cpp
@@ -17,6 +17,6 @@ int A_warp_glue(const array_float_t input, const array_float_t H,
 
 } // proximal
 
-PYBIND11_MODULE(libA_warp, m) {
+PYBIND11_MODULE(A_warp, m) {
     m.def("run", &proximal::A_warp_glue, "Apply affine transform");
 }

--- a/proximal/halide/interface/A_warp.cpp
+++ b/proximal/halide/interface/A_warp.cpp
@@ -8,9 +8,11 @@ int A_warp_glue(const array_float_t input, const array_float_t H,
 
         auto input_buf = getHalideBuffer<3>(input);
         auto H_buf = getHalideBuffer<3>(H);
-        auto output_buf = getHalideBuffer<4>(output);
+        auto output_buf = getHalideBuffer<4>(output, true);
 
-        return warpImg(input_buf, H_buf, output_buf);
+        const bool success = warpImg(input_buf, H_buf, output_buf);
+        output_buf.copy_to_host();
+        return success;
     }
 
 } // proximal

--- a/proximal/halide/interface/At_conv.cpp
+++ b/proximal/halide/interface/At_conv.cpp
@@ -8,9 +8,11 @@ int At_conv_glue(const array_float_t input, const array_float_t K,
 
         auto input_buf = getHalideBuffer<3>(input);
         auto K_buf = getHalideBuffer<3>(K);
-        auto output_buf = getHalideBuffer<3>(output);
+        auto output_buf = getHalideBuffer<3>(output, true);
 
-        return convImgT(input_buf, K_buf, output_buf);
+        const int success = convImgT(input_buf, K_buf, output_buf);
+        output_buf.copy_to_host();
+        return success;
     }
 
 } // proximal

--- a/proximal/halide/interface/At_conv.cpp
+++ b/proximal/halide/interface/At_conv.cpp
@@ -17,6 +17,6 @@ int At_conv_glue(const array_float_t input, const array_float_t K,
 
 } // proximal
 
-PYBIND11_MODULE(libAt_conv, m) {
+PYBIND11_MODULE(At_conv, m) {
     m.def("run", &proximal::At_conv_glue, "Apply 2D adjoint convolution");
 }

--- a/proximal/halide/interface/At_grad.cpp
+++ b/proximal/halide/interface/At_grad.cpp
@@ -15,6 +15,6 @@ At_grad_glue(const array_float_t input, array_float_t output) {
 
 }  // namespace proximal
 
-PYBIND11_MODULE(libAt_grad, m) {
+PYBIND11_MODULE(At_grad, m) {
     m.def("run", &proximal::At_grad_glue, "Compute adjoint of gradient");
 }

--- a/proximal/halide/interface/At_grad.cpp
+++ b/proximal/halide/interface/At_grad.cpp
@@ -6,9 +6,11 @@ namespace proximal {
 int
 At_grad_glue(const array_float_t input, array_float_t output) {
     auto input_buf = getHalideBuffer<4>(input);
-    auto output_buf = getHalideBuffer<3>(output);
+    auto output_buf = getHalideBuffer<3>(output, true);
 
-    return gradTransImg(input_buf, output_buf);
+    const int success = gradTransImg(input_buf, output_buf);
+    output_buf.copy_to_host();
+    return success;
 }
 
 }  // namespace proximal

--- a/proximal/halide/interface/At_mask.cpp
+++ b/proximal/halide/interface/At_mask.cpp
@@ -8,9 +8,11 @@ int At_mask(const array_float_t input, const array_float_t mask,
 
         auto input_buf = getHalideBuffer<3>(input);
         auto mask_buf = getHalideBuffer<3>(mask);
-        auto output_buf = getHalideBuffer<3>(output);
+        auto output_buf = getHalideBuffer<3>(output, true);
 
-        return WImg(input_buf, mask_buf, output_buf);
+        const bool success = WImg(input_buf, mask_buf, output_buf);
+        output_buf.copy_to_host();
+        return success;
     }
 
 } // proximal

--- a/proximal/halide/interface/At_mask.cpp
+++ b/proximal/halide/interface/At_mask.cpp
@@ -17,6 +17,6 @@ int At_mask(const array_float_t input, const array_float_t mask,
 
 } // proximal
 
-PYBIND11_MODULE(libAt_mask, m) {
+PYBIND11_MODULE(At_mask, m) {
     m.def("run", &proximal::At_mask, "Apply conjugate elementwise multiplication");
 }

--- a/proximal/halide/interface/At_warp.cpp
+++ b/proximal/halide/interface/At_warp.cpp
@@ -8,9 +8,11 @@ int At_warp_glue(const array_float_t input, const array_float_t H,
 
         auto input_buf = getHalideBuffer<4>(input);
         auto H_buf = getHalideBuffer<3>(H);
-        auto output_buf = getHalideBuffer<3>(output);
+        auto output_buf = getHalideBuffer<3>(output, true);
 
-        return warpImgT(input_buf, H_buf, output_buf);
+        const bool success = warpImgT(input_buf, H_buf, output_buf);
+        output_buf.copy_to_host();
+        return success;
     }
 
 } // proximal

--- a/proximal/halide/interface/At_warp.cpp
+++ b/proximal/halide/interface/At_warp.cpp
@@ -17,6 +17,6 @@ int At_warp_glue(const array_float_t input, const array_float_t H,
 
 } // proximal
 
-PYBIND11_MODULE(libAt_warp, m) {
+PYBIND11_MODULE(At_warp, m) {
     m.def("run", &proximal::At_warp_glue, "Apply inverse affine transform");
 }

--- a/proximal/halide/interface/fft2_r2c.cpp
+++ b/proximal/halide/interface/fft2_r2c.cpp
@@ -3,11 +3,11 @@
 
 namespace proximal {
 
-int fft2_r2c_glue(const array_float_t input, const int xshift, 
+int fft2_r2c_glue(const array_float_t input, const int xshift,
     const int yshift, array_complex_t output) {
 
         auto input_buf = getHalideBuffer<3>(input);
-        auto output_buf = getHalideComplexBuffer<4>(output);
+        auto output_buf = getHalideComplexBuffer<4>(output, true);
 
         return fftR2CImg(input_buf, xshift, yshift, output_buf);
     }

--- a/proximal/halide/interface/fft2_r2c.cpp
+++ b/proximal/halide/interface/fft2_r2c.cpp
@@ -14,6 +14,6 @@ int fft2_r2c_glue(const array_float_t input, const int xshift,
 
 } // proximal
 
-PYBIND11_MODULE(libfft2_r2c, m) {
+PYBIND11_MODULE(fft2_r2c, m) {
     m.def("run", &proximal::fft2_r2c_glue, "Apply 2D adjoint convolution");
 }

--- a/proximal/halide/interface/ifft2_c2r.cpp
+++ b/proximal/halide/interface/ifft2_c2r.cpp
@@ -6,7 +6,7 @@ namespace proximal {
 int ifft2_c2r_glue(const array_complex_t input, array_float_t output) {
 
         auto input_buf = getHalideComplexBuffer<4>(input);
-        auto output_buf = getHalideBuffer<3>(output);
+        auto output_buf = getHalideBuffer<3>(output, true);
 
         return ifftC2RImg(input_buf, output_buf);
     }

--- a/proximal/halide/interface/ifft2_c2r.cpp
+++ b/proximal/halide/interface/ifft2_c2r.cpp
@@ -13,6 +13,6 @@ int ifft2_c2r_glue(const array_complex_t input, array_float_t output) {
 
 } // proximal
 
-PYBIND11_MODULE(libifft2_c2r, m) {
+PYBIND11_MODULE(ifft2_c2r, m) {
     m.def("run", &proximal::ifft2_c2r_glue, "Apply 2D ifft");
 }

--- a/proximal/halide/interface/prox_IsoL1.cpp
+++ b/proximal/halide/interface/prox_IsoL1.cpp
@@ -15,6 +15,6 @@ int prox_IsoL1_glue(const array_float_t input, const float theta, array_float_t 
 
 } // proximal
 
-PYBIND11_MODULE(libprox_IsoL1, m) {
+PYBIND11_MODULE(prox_IsoL1, m) {
     m.def("run", &proximal::prox_IsoL1_glue, "Apply soft thresholding");
 }

--- a/proximal/halide/interface/prox_IsoL1.cpp
+++ b/proximal/halide/interface/prox_IsoL1.cpp
@@ -6,9 +6,11 @@ namespace proximal {
 int prox_IsoL1_glue(const array_float_t input, const float theta, array_float_t output) {
 
         auto input_buf = getHalideBuffer<4>(input);
-        auto output_buf = getHalideBuffer<4>(output);
+        auto output_buf = getHalideBuffer<4>(output, true);
 
-        return proxIsoL1(input_buf, theta, output_buf);
+        const bool success = proxIsoL1(input_buf, theta, output_buf);
+        output_buf.copy_to_host();
+        return success;
     }
 
 } // proximal

--- a/proximal/halide/interface/prox_L1.cpp
+++ b/proximal/halide/interface/prox_L1.cpp
@@ -15,6 +15,6 @@ int prox_L1_glue(const array_float_t input, const float theta, array_float_t out
 
 } // proximal
 
-PYBIND11_MODULE(libprox_L1, m) {
+PYBIND11_MODULE(prox_L1, m) {
     m.def("run", &proximal::prox_L1_glue, "Apply soft thresholding");
 }

--- a/proximal/halide/interface/prox_L1.cpp
+++ b/proximal/halide/interface/prox_L1.cpp
@@ -6,9 +6,11 @@ namespace proximal {
 int prox_L1_glue(const array_float_t input, const float theta, array_float_t output) {
 
         auto input_buf = getHalideBuffer<4>(input);
-        auto output_buf = getHalideBuffer<4>(output);
+        auto output_buf = getHalideBuffer<4>(output, true);
 
-        return proxL1(input_buf, theta, output_buf);
+        const int success = proxL1(input_buf, theta, output_buf);
+        output_buf.copy_to_host();
+        return success;
     }
 
 } // proximal

--- a/proximal/halide/interface/prox_Poisson.cpp
+++ b/proximal/halide/interface/prox_Poisson.cpp
@@ -19,6 +19,6 @@ prox_Poisson_glue(const array_float_t input, const array_float_t M, const array_
 
 }  // namespace proximal
 
-PYBIND11_MODULE(libprox_Poisson, m) {
+PYBIND11_MODULE(prox_Poisson, m) {
     m.def("run", &proximal::prox_Poisson_glue, "Apply proximal function of Poisson statistics");
 }

--- a/proximal/halide/interface/prox_Poisson.cpp
+++ b/proximal/halide/interface/prox_Poisson.cpp
@@ -10,9 +10,11 @@ prox_Poisson_glue(const array_float_t input, const array_float_t M, const array_
     auto M_buf = getHalideBuffer<3>(M);
     auto b_buf = getHalideBuffer<3>(b);
 
-    auto output_buf = getHalideBuffer<3>(output);
+    auto output_buf = getHalideBuffer<3>(output, true);
 
-    return proxPoisson(input_buf, M_buf, b_buf, theta, output_buf);
+    const bool success = proxPoisson(input_buf, M_buf, b_buf, theta, output_buf);
+    output_buf.copy_to_host();
+    return success;
 }
 
 }  // namespace proximal

--- a/proximal/halide/interface/util.hpp
+++ b/proximal/halide/interface/util.hpp
@@ -13,7 +13,7 @@ namespace {
 /** Return halide buffer, with broadcasting */
 template <int N, typename T>
 Halide::Runtime::Buffer<T>
-getHalideBuffer(py::array_t<T, py::array::f_style | py::array::forcecast> input) {
+getHalideBuffer(py::array_t<T, py::array::f_style | py::array::forcecast> input, bool host_dirty=true) {
     const int w = input.shape(1);
     const int h = input.shape(0);
     const int s = (input.ndim() >= 3) ? input.shape(2) : 1;
@@ -21,29 +21,44 @@ getHalideBuffer(py::array_t<T, py::array::f_style | py::array::forcecast> input)
 
     const auto buf = input.request();
     switch (N) {
-        case 2:
-            return Halide::Runtime::Buffer<T>{static_cast<T*>(buf.ptr), w, h};
-        case 3:
-            return Halide::Runtime::Buffer<T>{static_cast<T*>(buf.ptr), w, h, s};
-        default:
-            return Halide::Runtime::Buffer<T>{static_cast<T*>(buf.ptr), w, h, s, t};
+        case 2: {
+            Halide::Runtime::Buffer<T> b{static_cast<T*>(buf.ptr), w, h};
+            if (host_dirty) b.set_host_dirty();
+            return b;
+        }
+        case 3: {
+            Halide::Runtime::Buffer<T> b{static_cast<T*>(buf.ptr), w, h, s};
+            if (host_dirty) b.set_host_dirty();
+            return b;
+        }
+        default: {
+            Halide::Runtime::Buffer<T> b{static_cast<T*>(buf.ptr), w, h, s, t};
+            if (host_dirty) b.set_host_dirty();
+            return b;
+        }
     }
 }
 
 /** Return halide buffer, with broadcasting */
 template <int N, typename T>
 Halide::Runtime::Buffer<T>
-getHalideComplexBuffer(py::array_t<std::complex<T>, py::array::f_style | py::array::forcecast> input) {
+getHalideComplexBuffer(py::array_t<std::complex<T>, py::array::f_style | py::array::forcecast> input, bool host_dirty=true) {
     const int w = input.shape(1);
     const int h = input.shape(0);
     const int s = (input.ndim() >= 3) ? input.shape(2) : 1;
 
     const auto buf = input.request();
     switch (N) {
-        case 3:
-            return Halide::Runtime::Buffer<T>{static_cast<T*>(buf.ptr), 2, w, h};
-        default:
-            return Halide::Runtime::Buffer<T>{static_cast<T*>(buf.ptr), 2, w, h, s};
+        case 3: {
+            Halide::Runtime::Buffer<T> b{static_cast<T*>(buf.ptr), 2, w, h};
+            if (host_dirty) b.set_host_dirty();
+            return b;
+        }
+        default: {
+            Halide::Runtime::Buffer<T> b{static_cast<T*>(buf.ptr), 2, w, h, s};
+            if (host_dirty) b.set_host_dirty();
+            return b;
+        }
     }
 }
 

--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -99,7 +99,8 @@ pipeline_name = [[
         [],
 ]]
 
-python_dep = dependency('python3')
+py = import('python').find_installation('python3')
+python_dep = py.dependency()
 pybind11_dep = subproject('pybind11').get_variable('pybind11_dep')
 
 cuda_toolchain = find_program('nvcc', required: false)
@@ -151,10 +152,7 @@ foreach p : pipeline_name
     )
 
     foreach library_name : p[1]
-        # TODO: use meson python extension_module to infer the suffix
-        # of the library
-        #lib = py.extension_module(
-        lib = library(
+        lib = py.extension_module(
             library_name,
             sources: [
                 'interface/@0@.cpp'.format(library_name),
@@ -166,5 +164,7 @@ foreach p : pipeline_name
                 halide_runtime_dep,
             ],
         )
+
+        alias_target(library_name, lib)
     endforeach
 endforeach

--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -99,7 +99,7 @@ pipeline_name = [[
         [],
 ]]
 
-py = import('python').find_installation('python3')
+py = import('python').find_installation()
 python_dep = py.dependency()
 pybind11_dep = subproject('pybind11').get_variable('pybind11_dep')
 

--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -3,9 +3,10 @@ project('proximal-halide', 'cpp',
         'buildtype=debugoptimized',
 ])
 
-halide_toolchain = subproject('halide')
+halide_toolchain = subproject('halide-' + build_machine.cpu_family())
 halide_generator_dep = halide_toolchain.get_variable('halide_generator_dep')
 halide_runtime_dep = halide_toolchain.get_variable('halide_runtime_dep')
+halide_library_path = halide_toolchain.get_variable('halide_library_path')
 
 pipeline_src = [
     'src/A_conv.cpp',
@@ -89,19 +90,53 @@ pipeline_name = [[
     ], [
         'warpImg',
         ['A_warp'],
-        true,
+        false,
         [],
     ], [
         'warpImgT',
         ['At_warp'],
-        true,
+        false,
         [],
 ]]
 
 python_dep = dependency('python3')
 pybind11_dep = subproject('pybind11').get_variable('pybind11_dep')
 
+cuda_toolchain = find_program('nvcc', required: false)
+
 foreach p : pipeline_name
+    compile_cmd = [
+        'LD_LIBRARY_PATH=' + halide_library_path,
+        halide_generator,
+        '-o', meson.current_build_dir(),
+        '-g', p[0],
+        '-e', 'o,h',
+        'machine_params=4,6291000,40',
+    ]
+
+    auto_schedule = p[2]
+
+    if cuda_toolchain.found() and auto_schedule
+        compile_cmd += [
+            'target=host-cuda',
+            'auto_schedule=true',
+            '-s','Li2018',
+            '-p','autoschedule_li2018',
+        ]
+    elif auto_schedule
+        compile_cmd += [
+            'target=host',
+            'auto_schedule=true',
+            '-s','Mullapudi2016',
+            '-p','autoschedule_mullapudi2016',
+        ]
+    else
+        compile_cmd += [
+            'target=host',
+            'auto_schedule=false',
+        ]
+    endif
+
     obj = custom_target(
         p[0] + '.o',
         output: [
@@ -110,13 +145,7 @@ foreach p : pipeline_name
         ],
         input: halide_generator,
         command: [
-            halide_generator,
-            '-o', meson.current_build_dir(),
-            '-g', p[0],
-            '-e', 'o,h',
-            'target=host',
-            'auto_schedule=@0@'.format(p[2]),
-            'machine_params=8,6291000,40',
+            compile_cmd,
             p[3],
         ],
     )

--- a/proximal/halide/subprojects/halide-aarch64.wrap
+++ b/proximal/halide/subprojects/halide-aarch64.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = Halide-10.0.0-arm-64-linux
+
+source_url = https://github.com/halide/Halide/releases/download/v10.0.0/Halide-10.0.0-arm-64-linux-db901f7f7084025abc3cbb9d17b0f2d3f1745900.tar.gz
+source_filename = Halide-10.0.0-arm-64-linux.tar.gz
+source_hash = f686e14eb030f52d894837de04c5de09c619da4fd0e62e2da6d65ffa075b87d3
+
+patch_directory = halide
+
+

--- a/proximal/halide/subprojects/halide-x86_64.wrap
+++ b/proximal/halide/subprojects/halide-x86_64.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = Halide-10.0.0-x86-64-linux
+
+source_url = https://github.com/halide/Halide/releases/download/v10.0.0/Halide-10.0.0-x86-64-linux-db901f7f7084025abc3cbb9d17b0f2d3f1745900.tar.gz
+source_filename = Halide-10.0.0-x86-64-linux.tar.gz
+source_hash = 36c196e83c6727b358ea2bbeb60a70c491c698b0b95da6c07d5028f94a30c61c
+
+patch_directory = halide
+
+

--- a/proximal/halide/subprojects/halide.wrap
+++ b/proximal/halide/subprojects/halide.wrap
@@ -1,8 +1,0 @@
-[wrap-file]
-directory = halide
-
-source_url = https://github.com/halide/Halide/releases/download/v8.0.0/halide-linux-64-gcc53-800-65c26cba6a3eca2d08a0bccf113ca28746012cc3.tgz
-source_filename = halide-linux-64-gcc53-800.tar.gz
-source_hash = c67185d50a99adba86f6b2cc43c7e2cf11bcdfba9052d05e764a89b456a50446
-
-patch_directory = halide

--- a/proximal/halide/subprojects/packagefiles/halide/meson.build
+++ b/proximal/halide/subprojects/packagefiles/halide/meson.build
@@ -1,18 +1,22 @@
-project('halide toolchain', 'cpp')
+project('halide toolchain', 'cpp',
+    version: '10.0.0')
 
 cc = meson.get_compiler('cpp', native: true)
 
 halide_inc = include_directories('include')
-halide_lib = cc.find_library('Halide', dirs: join_paths(meson.current_source_dir(), 'bin'))
+halide_lib = cc.find_library('Halide', dirs: join_paths(meson.current_source_dir(), 'lib'))
 
 halide_generator_dep = declare_dependency(
     sources: [
-    'tools/GenGen.cpp',
+    'share/Halide/tools/GenGen.cpp',
     ],
     dependencies: halide_lib, 
     include_directories: halide_inc,
     compile_args: '-fno-rtti',
+    #native: true,
 )
+
+halide_library_path = meson.current_source_dir() / 'lib'
 
 if not meson.is_cross_build()
     cxx = meson.get_compiler('cpp')
@@ -20,7 +24,7 @@ if not meson.is_cross_build()
     halide_runtime_dep = declare_dependency(
         include_directories: [
             'include',
-            'tools',
+            'share/Halide/tools',
         ],
         dependencies: [
             dependency('libpng', required: false),

--- a/proximal/halide/subprojects/pybind11.wrap
+++ b/proximal/halide/subprojects/pybind11.wrap
@@ -1,10 +1,12 @@
 [wrap-file]
-directory = pybind11-2.3.0
+directory = pybind11-2.6.1
+source_url = https://github.com/pybind/pybind11/archive/v2.6.1.tar.gz
+source_filename = pybind11-2.6.1.tar.gz
+source_hash = cdbe326d357f18b83d10322ba202d69f11b2f49e2d87ade0dc2be0c5c34f8e2a
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/pybind11/2.6.1/1/get_zip
+patch_filename = pybind11-2.6.1-1-wrap.zip
+patch_hash = 6de5477598b56c8a2e609196420c783ac35b79a31d6622121602e6ade6b3cee8
 
-source_url = https://github.com/pybind/pybind11/archive/v2.3.0.zip
-source_filename = pybind11-2.3.0.zip
-source_hash = 1f844c071d9d98f5bb08458f128baa0aa08a9e5939a6b42276adb1bacd8b483e
+[provide]
+pybind11 = pybind11_dep
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/pybind11/2.3.0/2/get_zip
-patch_filename = pybind11-2.3.0-2-wrap.zip
-patch_hash = f3bed4bfc8961b3b985ff1e63fc6e57c674f35b353f0d42adbc037f9416381fb

--- a/proximal/lin_ops/mul_elemwise.py
+++ b/proximal/lin_ops/mul_elemwise.py
@@ -29,7 +29,7 @@ class mul_elemwise(LinOp):
 
             # Halide implementation
             tmpin = np.asfortranarray(inputs[0].astype(np.float32))
-            Halide('A_mask.cpp').A_mask(tmpin, self.weight, self.tmpout)  # Call
+            Halide('A_mask').run(tmpin, self.weight, self.tmpout)  # Call
             np.copyto(outputs[0], self.tmpout)
 
         else:


### PR DESCRIPTION
Upgrade to Halide 10 with CUDA autoscheduler
    
    Upgrade the Halide toolchain from 8.0 to 10.0, which in turn unlocks
    the following features:
    
     - (completed) to emit GPU accelerated image processing kernels;
     - (completed) to optimize / fuse CUDA kernels with the Li2018 autoscheduler;
     - (completed) supports either x86_64 or ARM environments
       (use-case of Halide on ARM: Nvidia Jetson SoB);
     - (TBD) to derive and accelerate the analytic first-order partial derivative
        of any proximal functions, aka the Autodiff;
     - (TBD) to derive and accelerate the output-weighted first-order partial
       derivative of any linear operations.
    
    The only catch is that the Halide provided fft routine is not
    compatible with Li2018-CUDA autoscheduler. Developers are
    encouraged to contribute the cuFFT interfaces to the ProxImaL project.
    
    Likewise, the Affine transform, warp() and warpT(), invokes
    the cyclic image boundary conditions; so far the Li2018 autoscheduler
    toolchain is unable to optimize such operations in CUDA.
    Developers who wish to make use of the feature can contact the
    Halide team for help.

---

Halide: support platforms beyond linux-x86
    
    This change utilizes the python extension module to generate the
    correct filename of the Halide-optimized Python bindings.
    
    For example, Python3.6 interpreter on 64-bit Linux OS will look for
    the following extension:
    
    proximal/halide/build/prox_L1.cpython-36m-x86_64-linux-gnu.so
    
    when the line `import proximal.halide.build.prox_L1` is encountered.
    
    Similarly, ARM architecture will look for the following pattern
    
    proximal/halide/build/prox_L1.cpython-36m-aarch64-linux-gnu.so
    
    to import the corresponding python module.
    
    ---
    
    TODO: To embed the hyperlink of the Halide toolchain for Windows OS
    
    https://github.com/halide/Halide/tree/v10.0.0
    
    in a new file:
    
    proximal/halide/subprojects/halide-windows.warp

