### PR TITLE
Set mesonbuild version

### DIFF
--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -1,4 +1,5 @@
 project('proximal-halide', 'cpp',
+    meson_version: '>=0.58.1',
     default_options: [
         'buildtype=debugoptimized',
 ])
@@ -107,7 +108,6 @@ cuda_toolchain = find_program('nvcc', required: false)
 
 foreach p : pipeline_name
     compile_cmd = [
-        'LD_LIBRARY_PATH=' + halide_library_path,
         halide_generator,
         '-o', meson.current_build_dir(),
         '-g', p[0],
@@ -145,6 +145,9 @@ foreach p : pipeline_name
             p[0] + '.h',
         ],
         input: halide_generator,
+        env: {
+            'LD_LIBRARY_PATH': halide_library_path,
+        },
         command: [
             compile_cmd,
             p[3],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-cov
 pillow
-meson
+meson==0.58.1
 numpy
 scipy
 cvxpy

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,4 @@ setup(
                       "numexpr",
                       "Pillow",
                       "meson >= 0.58"],
-    use_2to3=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
                       "scipy >= 0.15",
                       "numexpr",
                       "Pillow",
-                      "meson >= 0.54"],
+                      "meson >= 0.58"],
     use_2to3=True,
 )


### PR DESCRIPTION
Since Mesonbuild 0.57.0, environment variables like `LD_LIBRARY_PATH` can
be specified with the `env` arguments. Update the `meson.build` config
files accordingly.

Also, lock to `mesonbuild==0.58.1` in the `requirements.txt`.