### PR TITLE
Add missing test_data/meson.build

### DIFF
--- a/proximal/halide/src/test_data/meson.build
+++ b/proximal/halide/src/test_data/meson.build
@@ -1,0 +1,4 @@
+# TODO(Antony): Request Mesonbuild for the API: files(...).get_path()
+parrot_img_must_exist = files('parrot.png')
+
+parrot_img = meson.current_source_dir() / 'parrot.png'


### PR DESCRIPTION
Resolves Github Action test failure due to a missing build dependency file.