### PR TITLE
Disable C-to-F casting in Halide-accelerated functions

### DIFF
--- a/proximal/algorithms/admm.py
+++ b/proximal/algorithms/admm.py
@@ -52,19 +52,19 @@ def solve(psi_fns, omega_fns, rho=1.0,
     v_update = get_least_squares_inverse(op_list, None, try_diagonalize, verbose)
 
     # Initialize everything to zero.
-    v = np.zeros(K.input_size)
-    z = np.zeros(K.output_size)
-    u = np.zeros(K.output_size)
+    v = np.zeros(K.input_size, dtype=np.float32, order='F')
+    z = np.zeros(K.output_size, dtype=np.float32, order='F')
+    u = np.zeros(K.output_size, dtype=np.float32, order='F')
 
     # Initialize
     if x0 is not None:
-        v[:] = np.reshape(x0, K.input_size)
+        v[:] = np.asfortranarray(np.reshape(x0, K.input_size))
         K.forward(v, z)
 
     # Buffers.
-    Kv = np.zeros(K.output_size)
-    KTu = np.zeros(K.input_size)
-    s = np.zeros(K.input_size)
+    Kv = np.zeros(K.output_size, dtype=np.float32, order='F')
+    KTu = np.zeros(K.input_size, dtype=np.float32, order='F')
+    s = np.zeros(K.input_size, dtype=np.float32, order='F')
 
     # Log for prox ops.
     prox_log = TimingsLog(prox_fns)
@@ -94,10 +94,10 @@ def solve(psi_fns, omega_fns, rho=1.0,
         offset = 0
         for fn in psi_fns:
             slc = slice(offset, offset + fn.lin_op.size, None)
-            Kv_u_slc = np.reshape(Kv_u[slc], fn.lin_op.shape)
+            Kv_u_slc = np.asfortranarray(np.reshape(Kv_u[slc], fn.lin_op.shape))
             # Apply and time prox.
             prox_log[fn].tic()
-            z[slc] = fn.prox(rho, Kv_u_slc, i).flatten()
+            z[slc] = fn.prox(rho, Kv_u_slc, i).ravel()
             prox_log[fn].toc()
             offset += fn.lin_op.size
         # Update u.

--- a/proximal/algorithms/half_quadratic_splitting.py
+++ b/proximal/algorithms/half_quadratic_splitting.py
@@ -55,11 +55,11 @@ def solve(psi_fns, omega_fns,
 
     # Initialize
     if x0 is not None:
-        x = np.reshape(x0, K.input_size)
+        x = np.asfortranarray(np.reshape(x0, K.input_size))
     else:
-        x = np.zeros(K.input_size)
+        x = np.zeros(K.input_size, dtype=np.float32, order='F')
 
-    Kx = np.zeros(K.output_size)
+    Kx = np.zeros(K.output_size, dtype=np.float32, order='F')
     w = Kx.copy()
 
     # Temporary iteration counts
@@ -103,7 +103,7 @@ def solve(psi_fns, omega_fns,
                 slc = slice(offset, offset + fn.lin_op.size, None)
                 # Apply and time prox.
                 prox_log[fn].tic()
-                w[slc] = fn.prox(rho, np.reshape(Kx[slc], fn.lin_op.shape), ii).flatten()
+                w[slc] = fn.prox(rho, np.asfortranarray(np.reshape(Kx[slc], fn.lin_op.shape)), ii).ravel()
                 prox_log[fn].toc()
                 offset += fn.lin_op.size
 

--- a/proximal/algorithms/pock_chambolle.py
+++ b/proximal/algorithms/pock_chambolle.py
@@ -107,11 +107,11 @@ def solve(psi_fns, omega_fns, tau=None, sigma=None, theta=None,
             L = est_CompGraph_norm(K, try_fast_norm)
 
     # Initialize
-    x = adapter.zeros(K.input_size)
-    y = adapter.zeros(K.output_size)
-    xbar = adapter.zeros(K.input_size)
-    u = adapter.zeros(K.output_size)
-    z = adapter.zeros(K.output_size)
+    x = adapter.zeros(K.input_size, dtype=np.float32, order='F')
+    y = adapter.zeros(K.output_size, dtype=np.float32, order='F')
+    xbar = adapter.zeros(K.input_size, dtype=np.float32, order='F')
+    u = adapter.zeros(K.output_size, dtype=np.float32, order='F')
+    z = adapter.zeros(K.output_size, dtype=np.float32, order='F')
 
     if x0 is not None:
         x[:] = adapter.reshape(adapter.from_np(x0), K.input_size)
@@ -122,11 +122,11 @@ def solve(psi_fns, omega_fns, tau=None, sigma=None, theta=None,
     xbar[:] = x
 
     # Buffers.
-    Kxbar = adapter.zeros(K.output_size)
-    Kx = adapter.zeros(K.output_size)
-    KTy = adapter.zeros(K.input_size)
-    KTu = adapter.zeros(K.input_size)
-    s = adapter.zeros(K.input_size)
+    Kxbar = adapter.zeros(K.output_size, dtype=np.float32, order='F')
+    Kx = adapter.zeros(K.output_size, dtype=np.float32, order='F')
+    KTy = adapter.zeros(K.input_size, dtype=np.float32, order='F')
+    KTu = adapter.zeros(K.input_size, dtype=np.float32, order='F')
+    s = adapter.zeros(K.input_size, dtype=np.float32, order='F')
 
     prev_x = x.copy()
     prev_Kx = Kx.copy()

--- a/proximal/halide/interface/fft2_r2c.cpp
+++ b/proximal/halide/interface/fft2_r2c.cpp
@@ -4,7 +4,7 @@
 namespace proximal {
 
 int fft2_r2c_glue(const array_float_t input, const int xshift,
-    const int yshift, array_complex_t output) {
+    const int yshift, array_cxfloat_t output) {
 
         auto input_buf = getHalideBuffer<3>(input);
         auto output_buf = getHalideComplexBuffer<4>(output, true);

--- a/proximal/halide/interface/ifft2_c2r.cpp
+++ b/proximal/halide/interface/ifft2_c2r.cpp
@@ -3,7 +3,7 @@
 
 namespace proximal {
 
-int ifft2_c2r_glue(const array_complex_t input, array_float_t output) {
+int ifft2_c2r_glue(const array_cxfloat_t input, array_float_t output) {
 
         auto input_buf = getHalideComplexBuffer<4>(input);
         auto output_buf = getHalideBuffer<3>(output, true);

--- a/proximal/halide/interface/util.hpp
+++ b/proximal/halide/interface/util.hpp
@@ -5,15 +5,22 @@
 #include "HalideBuffer.h"
 
 namespace py = pybind11;
-using array_float_t = py::array_t<float, py::array::f_style | py::array::forcecast>;
-using array_complex_t = py::array_t<std::complex<float>, py::array::f_style | py::array::forcecast>;
+
+template<typename T>
+using array_t = py::array_t<T, py::array::f_style>;
+
+template<typename T>
+using array_complex_t = py::array_t<std::complex<T>, py::array::f_style>;
+
+using array_float_t = array_t<float>;
+using array_cxfloat_t = array_complex_t<float>;
 
 namespace {
 
 /** Return halide buffer, with broadcasting */
 template <int N, typename T>
 Halide::Runtime::Buffer<T>
-getHalideBuffer(py::array_t<T, py::array::f_style | py::array::forcecast> input, bool host_dirty=true) {
+getHalideBuffer(const array_t<T>& input, bool host_dirty=true) {
     const int w = input.shape(1);
     const int h = input.shape(0);
     const int s = (input.ndim() >= 3) ? input.shape(2) : 1;
@@ -42,7 +49,7 @@ getHalideBuffer(py::array_t<T, py::array::f_style | py::array::forcecast> input,
 /** Return halide buffer, with broadcasting */
 template <int N, typename T>
 Halide::Runtime::Buffer<T>
-getHalideComplexBuffer(py::array_t<std::complex<T>, py::array::f_style | py::array::forcecast> input, bool host_dirty=true) {
+getHalideComplexBuffer(const array_complex_t<T>& input, bool host_dirty=true) {
     const int w = input.shape(1);
     const int h = input.shape(0);
     const int s = (input.ndim() >= 3) ? input.shape(2) : 1;

--- a/proximal/lin_ops/comp_graph.py
+++ b/proximal/lin_ops/comp_graph.py
@@ -48,7 +48,7 @@ class CompGraph(object):
             for node in curr.input_nodes:
                 # Zero out constants. Constants are handled in absorb_offset
                 if isinstance(node, Constant):
-                    node = Constant(np.zeros(curr.shape))
+                    node = Constant(np.zeros(curr.shape, dtype=np.float32, order='F'))
                     node.orig_node = None
                     self.constants.append(node)
                 else:
@@ -385,7 +385,7 @@ class CompGraph(object):
             offset += var.size
             
     def x0(self):
-        res = np.zeros(self.input_size)
+        res = np.zeros(self.input_size, dtype=np.float32, order='F')
         for var in self.orig_end.variables():
             if var.initval is not None:
                 offset = self.var_info[var.uuid]

--- a/proximal/lin_ops/edge.py
+++ b/proximal/lin_ops/edge.py
@@ -8,7 +8,7 @@ class Edge(object):
         self.start = start
         self.end = end
         self.shape = shape
-        self.data = np.zeros(self.shape)
+        self.data = np.zeros(self.shape, dtype=np.float32, order='F')
         self.mag = None  # Used to get norm bounds.
 
     @property

--- a/proximal/lin_ops/lin_op.py
+++ b/proximal/lin_ops/lin_op.py
@@ -210,7 +210,7 @@ class LinOp(object):
         inputs = []
         for node in self.input_nodes:
             inputs.append(node.value)
-        output = np.zeros(self.shape)
+        output = np.zeros(self.shape, dtype=np.float32, order='F')
         self.forward(inputs, [output])
         return output
 

--- a/proximal/tests/test_halide.py
+++ b/proximal/tests/test_halide.py
@@ -3,11 +3,11 @@ import numpy as np
 from scipy.misc import ascent
 from scipy.signal import convolve2d
 
+import proximal as px
 from proximal.tests.base_test import BaseTest
-from proximal.utils.utils import get_test_image, get_kernel
 from proximal.halide.halide import Halide
 
-class TestLinOps(BaseTest):
+class TestHalideOps(BaseTest):
     def test_configure(self):
         """Test configuration of halide project
         """
@@ -17,10 +17,9 @@ class TestLinOps(BaseTest):
         """Test compilation
         """
         Halide('A_conv', reconfigure=True, recompile=True, verbose=False)
+    
 
-    def test_run(self):
-        """ Test running
-        """
+    def _get_testvector(self):
         # Load image
         np_img = np.asfortranarray(ascent(), dtype=np.float32)
 
@@ -28,11 +27,55 @@ class TestLinOps(BaseTest):
         K = np.ones((5,5), order='F', dtype=np.float32)
         K /= K.size
 
+        return np_img, K
+    
+
+    def test_run(self):
+        """ Test running
+        """
+        np_img, K = self._get_testvector()
+
         # Test Halide routine
-        output = np.zeros_like(np_img)
+        output = np.empty(np_img.shape, dtype=np.float32, order='F')
         Halide('A_conv', recompile=True).run(np_img, K, output)
 
         # Test numpy implementation
         output_ref = convolve2d(np_img, K, mode='same', boundary='wrap')
 
         self.assertItemsAlmostEqual(output, output_ref)
+    
+    def _test_algo(self, algo, check_convergence=True):
+        """ Ensure all internal buffers of the algortihms are Fortran-style ordered.
+        """
+        np_img, K = self._get_testvector()
+        X = px.Variable(np_img.shape)
+
+        # Force the build system to re-compile the Halide-accelerated prox_L1 function.
+        # It is also a good time to assert for np.array(dtype=float32, order='F') .
+        prox_fns = [px.norm1(X, b=np_img, beta=2, implem='halide')]
+        output = np.empty(np_img.shape, dtype=np.float32, order='F')
+        Halide('prox_L1', recompile=True).run(np_img, 1.0, output)
+
+        # Ensure all the internal buffers are float32 type, in F-style data layout.
+        sltn = algo.solve(prox_fns, [],
+                        max_iters=500,
+                        eps_rel=1e-5,
+                        eps_abs=1e-5)
+
+        if check_convergence:
+            # Convergence testing is not the goal of this unit test case. Write
+            # a separate test case for this.
+            self.assertAlmostEqual(sltn, 0, eps=2e-2)
+            self.assertItemsAlmostEqual(X.value, np_img / 2., eps=2e-2)
+
+    def test_ladmm(self):
+        self._test_algo(px.ladmm)
+
+    def test_admm(self):
+        self._test_algo(px.admm)
+
+    def test_pc(self):
+        self._test_algo(px.pc)
+
+    def test_hqs(self):
+        self._test_algo(px.hqs)

--- a/proximal/tests/test_lin_ops.py
+++ b/proximal/tests/test_lin_ops.py
@@ -114,7 +114,7 @@ class TestLinOps(BaseTest):
 
         fn.forward([x], [out])
         ks = np.array(kernel.shape)
-        cc = np.floor((ks - 1) / 2.0).astype(np.int)  # Center coordinate
+        cc = np.floor((ks - 1) / 2.0).astype(np.int32)  # Center coordinate
         y = np.zeros((2, 3))
         for i in range(2):
             for j in range(3):

--- a/proximal/utils/cuda_codegen.py
+++ b/proximal/utils/cuda_codegen.py
@@ -50,7 +50,7 @@ class NumpyAdapter:
     To keep algorithms free of cuda clutter, we use these adapter classes to map
     calls to either numpy or gpuarray.
     """
-    def __init__(self, floattype = np.float64):
+    def __init__(self, floattype = np.float32):
         self.floattype = floattype
 
     def zeros(self, *args, **kw):
@@ -67,10 +67,11 @@ class NumpyAdapter:
         return self.floattype(s)
 
     def reshape(self, *args):
-        return np.reshape(*args)
+        # Not sure why np.reshape(..., order='F') doesn't work.
+        return np.asfortranarray(np.reshape(*args))
 
     def flatten(self, matrix):
-        return matrix.flatten()
+        return matrix.ravel()
 
     def copyto(self, tgt, src):
         np.copyto(tgt, src)


### PR DESCRIPTION
Assert these criteria only when `implem == 'halide'`: For output buffers of all Prox functions, ensure they are in single-precision (float32) datatype, arranged in the Fortran-style order.

This resolves a bug: (L-)ADMM fails to converge when we explicitly define `proxL1(..., implem='halide')` in the problem. Previously, the Python interface `Pybind11` dynamically casts the output Numpy buffers from `float64` to a temporary buffer as type `float32`, asks Halide runtime to it, then immediately destroys the temp buffer.

Create a new test case `proximal.tests.test_halide.TestHalideOps._test_algos` to ensure algorithm convergence when Halide-accelerated Prox functions are specified in the problem.

---

Similarly, ensure all input buffers are in single-precision datatype in Fortran-style order.

Rationale: Halide-acceleration of the Prox functions are only justified when we can avoid the explicit memory copy and type casting. Otherwise, the Halide implementation can run slower than the native Numpy/Numexpr implementation.

Related to #67 .