### PR TITLE
Upgrade Halide toolchain to 14.0

### DIFF
--- a/proximal/halide/src/algorithm/linearized-admm.h
+++ b/proximal/halide/src/algorithm/linearized-admm.h
@@ -43,7 +43,7 @@ norm(const FuncTuple<N>& v, const RDom r) {
 namespace algorithm {
 namespace linearized_admm {
 
-template <LinOpGraph G, size_t N, Prox P, Prox P2>
+template <size_t N, LinOpGraph G, Prox P, Prox P2>
 std::tuple<Func, FuncTuple<N>, FuncTuple<N>>
 iterate(const Func& v, const FuncTuple<N>& z, const FuncTuple<N>& u, G& K, const P& omega_fn,
         std::array<P2, N> psi_fns, const Expr& lmb, const Expr& mu, const Func& b) {
@@ -98,7 +98,7 @@ iterate(const Func& v, const FuncTuple<N>& z, const FuncTuple<N>& u, G& K, const
     return {v_new, z_new, u_new};
 }
 
-template <LinOpGraph G, size_t N>
+template <size_t N, LinOpGraph G>
 std::tuple<Expr, Expr, Expr, Expr>
 computeConvergence(const Func& v, const FuncTuple<N>& z, const FuncTuple<N>& u,
                    const FuncTuple<N>& z_prev, G& K, const float lmb, const uint32_t input_size,

--- a/proximal/halide/src/algorithm/problem-interface.h
+++ b/proximal/halide/src/algorithm/problem-interface.h
@@ -28,23 +28,25 @@ using FuncTuple = std::array<Halide::Func, N>;
  * two member functions: K.forward(), and K.adjoint().
  */
 template <typename T, size_t N>
-concept LinOpGraph = requires(T a) {
+concept LinOpGraphImpl = requires(T a, const Halide::Func& f, const FuncTuple<N>& ft) {
     // forward function expects a Halide::Func as a data plane / data cube, and
     // returns a tuple of data planes.
-    { a.forward(Halide::Func) }
-    ->FuncTuple<N>;
+    { a.forward(f) }
+    -> std::same_as<FuncTuple<N>>;
 
     // adjoint function expects an array of Halide::Func, and returns
     // one single Func.
-    { a.adjoint(const FuncTuple<N>&) }
-    ->Halide::Func;
+    { a.adjoint(ft) }
+    -> std::same_as<Halide::Func>;
 };
 
 template <typename T>
-concept Prox = requires(T a) {
-    { a.operator()(const Func&, const Expr&, const Func&) }
-    ->Halide::Func;
+concept Prox = requires(T a, const Halide::Func& f, const Halide::Expr& e) {
+    { a.operator()(f, e, f) }
+    -> std::same_as<Halide::Func>;
 };
+
+#define LinOpGraph LinOpGraphImpl<N>
 
 #else
 

--- a/proximal/halide/src/core/image_formation.h
+++ b/proximal/halide/src/core/image_formation.h
@@ -42,7 +42,7 @@ Func At_conv(Func input, Expr width, Expr height, Func K, Expr filter_width, Exp
 
     //Clamped
     Func img_bounded("img_bounded");
-    img_bounded = BoundaryConditions::repeat_image(input, 0, width, 0, height);
+    img_bounded = BoundaryConditions::repeat_image(input, {{0, width}, {0, height}});
 
     //Define the convolution
     Func img_conv("img_conv");

--- a/proximal/halide/src/fft/LICENSE.txt
+++ b/proximal/halide/src/fft/LICENSE.txt
@@ -1,0 +1,233 @@
+Copyright (c) 2012-2020 MIT CSAIL, Google, Facebook, Adobe, NVIDIA CORPORATION, and other contributors.
+
+Developed by:
+
+  The Halide team
+  http://halide-lang.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
+apps/bgu is Copyright 2016 Google Inc. and is Licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in compliance
+with the License.
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with
+that entity. For the purposes of this definition, "control" means (i) the
+power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+(50%) or more of the outstanding shares, or (iii) beneficial ownership of such
+entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative
+Works shall not include works that remain separable from, or merely link (or
+bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated
+in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any
+part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy of
+the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part of
+the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the
+Derivative Works, if and wherever such third-party notices normally appear.
+The contents of the NOTICE file are for informational purposes only and do not
+modify the License. You may add Your own attribution notices within Derivative
+Works that You distribute, alongside or as an addendum to the NOTICE text from
+the Work, provided that such additional attribution notices cannot be
+construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+-----
+
+apps/support/cmdline.h is Copyright (c) 2009, Hideyuki Tanaka and is licensed
+under the BSD 3-Clause license.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of the <organization> nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY <copyright holder> ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <copyright holder> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----
+
+dependencies/spirv is Copyright (c) 2014-2018 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and/or associated documentation files (the "Materials"),
+to deal in the Materials without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Materials, and to permit persons to whom the
+Materials are furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Materials.
+
+MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS KHRONOS
+STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS SPECIFICATIONS AND
+HEADER INFORMATION ARE LOCATED AT https://www.khronos.org/registry/
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM,OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS
+IN THE MATERIALS.
+
+
+----
+
+src/mini_vulkan.h is Copyright (c) 2014-2017 The Khronos Group Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+----
+
+apps/linear_algebra/include/cblas.h is licensed under the BLAS license.
+
+The reference BLAS is a freely-available software package. It is available from
+netlib via anonymous ftp and the World Wide Web. Thus, it can be included in
+commercial software packages (and has been). We only ask that proper credit be
+given to the authors.
+
+Like all software, it is copyrighted. It is not trademarked, but we do ask the
+following:
+
+If you modify the source for these routines we ask that you change the name of
+the routine and comment the changes made to the original.
+
+We will gladly answer any questions regarding the software. If a modification is
+done, however, it is the responsibility of the person who modified the routine
+to provide support.
+

--- a/proximal/halide/src/fft/funct.h
+++ b/proximal/halide/src/fft/funct.h
@@ -59,7 +59,7 @@ public:
     }
 
     template<typename... Args>
-    FuncRefT<T> operator()(Args &&... args) const {
+    FuncRefT<T> operator()(Args &&...args) const {
         return Func::operator()(std::forward<Args>(args)...);
     }
 

--- a/proximal/halide/src/fft2_r2c.cpp
+++ b/proximal/halide/src/fft2_r2c.cpp
@@ -55,7 +55,7 @@ public:
         //Input
         Func input_func("in");
         Func paddedInput("paddedInput");
-        paddedInput = repeat_image( constant_exterior(input, 0.f), 0, wtarget, 0, htarget);
+        paddedInput = repeat_image( constant_exterior(input, 0.f), {{0, wtarget}, {0, htarget}});
         input_func(x, y, c) = paddedInput( x + shiftx, y + shifty, c );
 
         //Warping

--- a/proximal/halide/src/user-problem/problem-definition.h
+++ b/proximal/halide/src/user-problem/problem-definition.h
@@ -49,12 +49,6 @@ struct Transform {
     }
 } K;
 
-#if __cplusplus >= 202002L
-
-// If C++20 is supported, validate the transform structure.
-static_assert(LinOpGrah<Transform>);
-#endif
-
 /** List of functions in set Omega, after problem splitting by ProxImaL. */
 const ParameterizedProx omega_fn{
     /* Begin code-generation */

--- a/proximal/halide/subprojects/halide-x86_64-linux.wrap
+++ b/proximal/halide/subprojects/halide-x86_64-linux.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = Halide-10.0.0-x86-64-linux
+directory = Halide-14.0.0-x86-64-linux
 
-source_url = https://github.com/halide/Halide/releases/download/v10.0.0/Halide-10.0.0-x86-64-linux-db901f7f7084025abc3cbb9d17b0f2d3f1745900.tar.gz
-source_filename = Halide-10.0.0-x86-64-linux.tar.gz
-source_hash = 36c196e83c6727b358ea2bbeb60a70c491c698b0b95da6c07d5028f94a30c61c
+source_url = https://github.com/halide/Halide/releases/download/v14.0.0/Halide-14.0.0-x86-64-linux-6b9ed2afd1d6d0badf04986602c943e287d44e46.tar.gz
+source_filename = Halide-14.0.0-x86-64-linux.tar.gz
+source_hash = be3bdd067acb9ee0d37d0830821113cd69174bee46da466a836d8829fef7cf91
 
 patch_directory = halide
 

--- a/proximal/halide/subprojects/halide-x86_64-windows.wrap
+++ b/proximal/halide/subprojects/halide-x86_64-windows.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = Halide-10.0.0-x86-64-windows
+directory = Halide-14.0.0-x86-64-windows
 
-source_url = https://github.com/halide/Halide/releases/download/v10.0.0/Halide-10.0.0-x86-64-windows-db901f7f7084025abc3cbb9d17b0f2d3f1745900.zip
-source_filename = Halide-10.0.0-x86-64-windows.zip
-source_hash = 0f61525267177fd7c0b9ddbb12a4723e6edd89e2ceede930c3a2b447d15f80a5
+source_url = https://github.com/halide/Halide/releases/download/v14.0.0/Halide-14.0.0-x86-64-windows-6b9ed2afd1d6d0badf04986602c943e287d44e46.zip
+source_filename = Halide-14.0.0-x86-64-windows.zip
+source_hash = a7a0481af2691ec436d79c20ca441e9a701bfce409f4f763dab75a8f1d740179
 
 patch_directory = halide
 

--- a/proximal/halide/subprojects/packagefiles/halide/meson.build
+++ b/proximal/halide/subprojects/packagefiles/halide/meson.build
@@ -1,5 +1,5 @@
 project('halide toolchain', 'cpp',
-    version: '10.0.0')
+    version: '14.0.0')
 
 cc = meson.get_compiler('cpp', native: true)
 


### PR DESCRIPTION
Upgrade the Halide toolchain from 10.0 to 14.0. Use the new API `BoundaryCondition::repeat_edge(Func,std::vector)` to define image dimensions.

Download the latest Halide-FFT source code. Include the 3rd party MIT license.

Resolve C++20 Concepts syntax error. To validate C++20 compatibility, run `meson configure -Dcpp_std=c++20` in the build directory.

This PR sets the stage for a major API change in Halide 16.0, where `Halide::Generator::Input<int, n_dim>` and `Generator::using_autoscheduler()` is favored over the current syntax.
