### PR TITLE
Upgrade to Halide 16.0 to enable Anderson2021 GPU algorithm optimizer

### DIFF
--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -125,7 +125,6 @@ foreach p : pipeline_name
         '-o', meson.current_build_dir(),
         '-g', p[0],
         '-e', 'o,h',
-        'machine_params=4,6291000,40',
     ]
 
     auto_schedule = p[2]
@@ -133,21 +132,25 @@ foreach p : pipeline_name
     if cuda_toolchain.found() and auto_schedule
         compile_cmd += [
             'target=host-cuda',
-            'auto_schedule=true',
-            '-s','Li2018',
-            '-p','autoschedule_li2018',
+            '-p', 'autoschedule_li2018',
+            'autoscheduler=Li2018',
+            'autoscheduler.parallelism=32',
         ]
     elif auto_schedule
         compile_cmd += [
             'target=host',
-            'auto_schedule=true',
-            '-s','Mullapudi2016',
-            '-p','autoschedule_mullapudi2016',
+            '-p', 'autoschedule_mullapudi2016',
+            'autoscheduler=Mullapudi2016',
+            # Maximum level of CPU core, or GPU threads available
+            'autoscheduler.parallelism=4',
+            # Size of last level (L2) cache
+            'autoscheduler.last_level_cache_size=6291000',
+            # Ratio of the cache read cost to compute cost
+            'autoscheduler.balance=40',
         ]
     else
         compile_cmd += [
             'target=host',
-            'auto_schedule=false',
         ]
     endif
 

--- a/proximal/halide/src/A_conv.cpp
+++ b/proximal/halide/src/A_conv.cpp
@@ -11,9 +11,9 @@ using namespace Halide::BoundaryConditions;
 class conv_gen : public Generator<conv_gen> {
 public:
 
-    Input<Buffer<float>> input{"input", 3};
-    Input<Buffer<float>> K{"K", 3};
-    Output<Buffer<float>> conv_output{"output", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Input<Buffer<float, 3>> K{"K"};
+    Output<Buffer<float, 3>> conv_output{"output"};
     
     void generate () {
         Expr width = input.width();

--- a/proximal/halide/src/A_conv.cpp
+++ b/proximal/halide/src/A_conv.cpp
@@ -27,7 +27,7 @@ public:
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             K.set_estimates({{0, 15}, {0, 15}, {0, 1}});
             conv_output.set_estimates({{0, 512}, {0, 512}, {0, 1}});

--- a/proximal/halide/src/A_grad.cpp
+++ b/proximal/halide/src/A_grad.cpp
@@ -10,8 +10,8 @@ using namespace Halide::BoundaryConditions;
 
 class grad_gen : public Generator<grad_gen> {
    public:
-    Input<Buffer<float>> input{"input", 3};
-    Output<Buffer<float>> output{"output", 4};
+    Input<Buffer<float, 3>> input{"input"};
+    Output<Buffer<float, 4>> output{"output"};
 
     void generate() {
         Expr width = input.width();

--- a/proximal/halide/src/A_grad.cpp
+++ b/proximal/halide/src/A_grad.cpp
@@ -22,7 +22,7 @@ class grad_gen : public Generator<grad_gen> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             output.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
             return;

--- a/proximal/halide/src/A_mask.cpp
+++ b/proximal/halide/src/A_mask.cpp
@@ -24,7 +24,7 @@ class mask_gen : public Generator<mask_gen> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             mask.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             output.set_estimates({{0, 512}, {0, 512}, {0, 1}});

--- a/proximal/halide/src/A_mask.cpp
+++ b/proximal/halide/src/A_mask.cpp
@@ -10,9 +10,9 @@ using namespace Halide::BoundaryConditions;
 
 class mask_gen : public Generator<mask_gen> {
    public:
-    Input<Buffer<float>> input{"input", 3};
-    Input<Buffer<float>> mask{"mask", 3};
-    Output<Buffer<float>> output{"output", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Input<Buffer<float, 3>> mask{"mask"};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         // Image dimensions

--- a/proximal/halide/src/A_warp.cpp
+++ b/proximal/halide/src/A_warp.cpp
@@ -11,9 +11,9 @@ using namespace Halide::BoundaryConditions;
 
 class warp_gen : public Generator<warp_gen> {
    public:
-    Input<Buffer<float>> input{"input", 3};
-    Input<Buffer<float>> H{"H", 3};
-    Output<Buffer<float>> output{"output", 4};
+    Input<Buffer<float, 3>> input{"input"};
+    Input<Buffer<float, 3>> H{"H"};
+    Output<Buffer<float, 4>> output{"output"};
 
     void generate() {
         Expr width = input.width();

--- a/proximal/halide/src/A_warp.cpp
+++ b/proximal/halide/src/A_warp.cpp
@@ -32,7 +32,7 @@ class warp_gen : public Generator<warp_gen> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             H.set_estimates({{0, 3}, {0, 3}, {0, 1}});
             output.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});

--- a/proximal/halide/src/At_conv.cpp
+++ b/proximal/halide/src/At_conv.cpp
@@ -11,9 +11,9 @@ using namespace Halide::BoundaryConditions;
 class conv_trans_gen : public Generator<conv_trans_gen> {
 public:
 
-    Input<Buffer<float>> input{"input", 3};
-    Input<Buffer<float>> K{"K", 3};
-    Output<Buffer<float>> conv_trans_input{"output", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Input<Buffer<float, 3>> K{"K"};
+    Output<Buffer<float, 3>> conv_trans_input{"output"};
     
     void generate() {
         Expr width = input.width();

--- a/proximal/halide/src/At_conv.cpp
+++ b/proximal/halide/src/At_conv.cpp
@@ -27,7 +27,7 @@ public:
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             K.set_estimates({{0, 15}, {0, 15}, {0, 1}});
             conv_trans_input.set_estimates({{0, 512}, {0, 512}, {0, 1}});

--- a/proximal/halide/src/At_grad.cpp
+++ b/proximal/halide/src/At_grad.cpp
@@ -22,7 +22,7 @@ class grad_trans_gen : public Generator<grad_trans_gen> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
             output.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             return;

--- a/proximal/halide/src/At_grad.cpp
+++ b/proximal/halide/src/At_grad.cpp
@@ -10,8 +10,8 @@ using namespace Halide::BoundaryConditions;
 
 class grad_trans_gen : public Generator<grad_trans_gen> {
    public:
-    Input<Buffer<float>> input{"input", 4};
-    Output<Buffer<float>> output{"output", 3};
+    Input<Buffer<float, 4>> input{"input"};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         Expr width = input.width();

--- a/proximal/halide/src/At_warp.cpp
+++ b/proximal/halide/src/At_warp.cpp
@@ -34,7 +34,7 @@ class warp_trans_gen : public Generator<warp_trans_gen> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 1}});
             Hinv.set_estimates({{0, 3}, {0, 3}, {0, 1}});
             output.set_estimates({{0, 512}, {0, 512}, {0, 1}});

--- a/proximal/halide/src/At_warp.cpp
+++ b/proximal/halide/src/At_warp.cpp
@@ -13,9 +13,9 @@ class warp_trans_gen : public Generator<warp_trans_gen> {
     Var xo, xi;
 
    public:
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> Hinv{"H", 3};
-    Output<Buffer<float>> output{"output", 3};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 3>> Hinv{"H"};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         Expr width = input.width();

--- a/proximal/halide/src/core/image_formation.h
+++ b/proximal/halide/src/core/image_formation.h
@@ -61,7 +61,6 @@ Func At_conv(Func input, Expr width, Expr height, Func K, Expr filter_width, Exp
 //Mask diagonal weighting matrix
 Func A_M(Func input, Expr width, Expr height, Func mask) {
 
-	int vec_width = 8;
     //Define the mask
     Func input_mask("input_mask");
     input_mask(x, y, c) = mask(x, y, c) * input(x, y, c);

--- a/proximal/halide/src/fft/fft.cpp
+++ b/proximal/halide/src/fft/fft.cpp
@@ -107,7 +107,7 @@ ComplexExpr mul(ComplexExpr a, float re_b, float im_b) {
 // Specializations for some small DFTs of the first dimension of a
 // Func f.
 ComplexFunc dft2(ComplexFunc f, const string &prefix) {
-    Type type = f.output_types()[0];
+    Type type = f.types()[0];
 
     ComplexFunc F(prefix + "X2");
     F(f.args()) = undef_z(type);
@@ -122,7 +122,7 @@ ComplexFunc dft2(ComplexFunc f, const string &prefix) {
 }
 
 ComplexFunc dft4(ComplexFunc f, int sign, const string &prefix) {
-    Type type = f.output_types()[0];
+    Type type = f.types()[0];
 
     ComplexFunc F(prefix + "X4");
     F(f.args()) = undef_z(type);
@@ -156,7 +156,7 @@ ComplexFunc dft6(ComplexFunc f, int sign, const string &prefix) {
     ComplexExpr W2_3(re_W1_3, -im_W1_3);
     ComplexExpr W4_3 = W1_3;
 
-    Type type = f.output_types()[0];
+    Type type = f.types()[0];
 
     ComplexFunc F(prefix + "X8");
     F(f.args()) = undef_z(type);
@@ -187,7 +187,7 @@ ComplexFunc dft6(ComplexFunc f, int sign, const string &prefix) {
 ComplexFunc dft8(ComplexFunc f, int sign, const string &prefix) {
     const float sqrt2_2 = 0.70710678f;
 
-    Type type = f.output_types()[0];
+    Type type = f.types()[0];
 
     ComplexFunc F(prefix + "X8");
     F(f.args()) = undef_z(type);
@@ -346,7 +346,7 @@ ComplexFunc fft_dim1(ComplexFunc x,
 
         // The vector width is the least common multiple of the previous vector
         // width and the natural vector size for this stage.
-        vector_width = lcm(vector_width, target.natural_vector_size(v.output_types()[0]));
+        vector_width = lcm(vector_width, target.natural_vector_size(v.types()[0]));
 
         // Compute the R point DFT of the subtransform.
         ComplexFunc V = dft1d_c2c(v, R, sign, prefix);
@@ -355,7 +355,7 @@ ComplexFunc fft_dim1(ComplexFunc x,
         // pass. Since the pure stage is undef, we explicitly generate the
         // arg list (because we can't use placeholders in an undef
         // definition).
-        exchange(A({n0, n1}, args)) = undef_z(V.output_types()[0]);
+        exchange(A({n0, n1}, args)) = undef_z(V.types()[0]);
 
         RDom rs(0, R, 0, N / R);
         r_ = rs.x;
@@ -444,7 +444,7 @@ std::pair<FuncType, FuncType> tiled_transpose(FuncType f, int max_tile_size,
     }
 
     const int tile_size =
-        std::min(max_tile_size, target.natural_vector_size(f.output_types()[0]));
+        std::min(max_tile_size, target.natural_vector_size(f.types()[0]));
 
     vector<Var> args = f.args();
     Var x(args[0]), y(args[1]);
@@ -685,7 +685,7 @@ ComplexFunc fft2d_r2c(Func r,
     int N0 = product(R0);
     int N1 = product(R1);
 
-    const int natural_vector_size = target.natural_vector_size(r.output_types()[0]);
+    const int natural_vector_size = target.natural_vector_size(r.types()[0]);
 
     // If this FFT is small, the logic related to zipping and unzipping
     // the FFT may be expensive compared to just brute forcing with a complex
@@ -705,7 +705,7 @@ ComplexFunc fft2d_r2c(Func r,
         result(A({n0, n1}, args)) = dft(A({n0, n1}, args));
         result.bound(n0, 0, N0);
         result.bound(n1, 0, (N1 + 1) / 2 + 1);
-        result.vectorize(n0, std::min(N0, target.natural_vector_size(result.output_types()[0])));
+        result.vectorize(n0, std::min(N0, target.natural_vector_size(result.types()[0])));
         dft.compute_at(result, outer);
         return result;
     }
@@ -731,7 +731,7 @@ ComplexFunc fft2d_r2c(Func r,
     ComplexFunc zipped(prefix + "zipped");
     int zip_width = desc.vector_width;
     if (zip_width <= 0) {
-        zip_width = target.natural_vector_size(r.output_types()[0]);
+        zip_width = target.natural_vector_size(r.types()[0]);
     }
     // Ensure the zip width divides the zipped extent.
     zip_width = gcd(zip_width, N0 / 2);
@@ -911,7 +911,7 @@ Func fft2d_c2r(ComplexFunc c,
     // If this FFT is small, the logic related to zipping and unzipping
     // the FFT may be expensive compared to just brute forcing with a complex
     // FFT.
-    const int natural_vector_size = target.natural_vector_size(c.output_types()[0]);
+    const int natural_vector_size = target.natural_vector_size(c.types()[0]);
 
     bool skip_zip = N0 < natural_vector_size * 2;
 
@@ -967,7 +967,7 @@ Func fft2d_c2r(ComplexFunc c,
         // The vector width of the zipping performed below.
         int zip_width = desc.vector_width;
         if (zip_width <= 0) {
-            zip_width = gcd(target.natural_vector_size(dft0T.output_types()[0]), N1 / 2);
+            zip_width = gcd(target.natural_vector_size(dft0T.types()[0]), N1 / 2);
         }
 
         // transpose so we can take the DFT of the columns again.

--- a/proximal/halide/src/fft2_r2c.cpp
+++ b/proximal/halide/src/fft2_r2c.cpp
@@ -43,12 +43,12 @@ Func fft2_r2c(Func input, int W, int H) {
 class fft2_r2c_gen : public Generator<fft2_r2c_gen> {
 public:
 
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     Input<int> shiftx{"shiftx"};
     Input<int> shifty{"shifty"};
     GeneratorParam<int> wtarget{"wtarget", 512, 2, 4096};
     GeneratorParam<int> htarget{"htarget", 512, 2, 4096};
-    Output<Buffer<float>> fftIn{"fftIn", 4};
+    Output<Buffer<float, 4>> fftIn{"fftIn"};
 
     void generate() {
 

--- a/proximal/halide/src/fft2_r2c.cpp
+++ b/proximal/halide/src/fft2_r2c.cpp
@@ -63,7 +63,7 @@ public:
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             return;
         }
 

--- a/proximal/halide/src/ifft2_c2r.cpp
+++ b/proximal/halide/src/ifft2_c2r.cpp
@@ -35,8 +35,8 @@ Func ifft2_c2r(Func input, int W, int H) {
 class ifft2_c2r_gen : public Generator<ifft2_c2r_gen> {
 public:
 
-    Input<Buffer<float>> input{"input", 4};
-    Output<Buffer<float>> fftOut{"output", 3};
+    Input<Buffer<float, 4>> input{"input"};
+    Output<Buffer<float, 3>> fftOut{"output"};
 
     GeneratorParam<int> wtarget{"wtarget", 512, 2, 1024};
     GeneratorParam<int> htarget{"htarget", 512, 2, 1024};

--- a/proximal/halide/src/prox_IsoL1.cpp
+++ b/proximal/halide/src/prox_IsoL1.cpp
@@ -27,6 +27,7 @@ public:
         if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
             output.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
+            theta.set_estimate(1.0f);
             return;
         }
 

--- a/proximal/halide/src/prox_IsoL1.cpp
+++ b/proximal/halide/src/prox_IsoL1.cpp
@@ -24,7 +24,7 @@ public:
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
             output.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
             return;

--- a/proximal/halide/src/prox_IsoL1.cpp
+++ b/proximal/halide/src/prox_IsoL1.cpp
@@ -11,9 +11,9 @@ using namespace Halide::BoundaryConditions;
 class proxIsoL1_gen : public Generator<proxIsoL1_gen> {
 public:
 
-    Input<Buffer<float>> input{"input", 4};
+    Input<Buffer<float, 4>> input{"input"};
     Input<float> theta{"theta"};
-    Output<Buffer<float>> output{"output", 4};
+    Output<Buffer<float, 4>> output{"output"};
 
     void generate() {
         Expr width = input.width();

--- a/proximal/halide/src/prox_L1.cpp
+++ b/proximal/halide/src/prox_L1.cpp
@@ -11,9 +11,9 @@ using namespace Halide::BoundaryConditions;
 class proxL1_gen : public Generator<proxL1_gen> {
 public:
 
-    Input<Buffer<float>> input{"input", 4};
+    Input<Buffer<float, 4>> input{"input"};
     Input<float> theta{"theta"};
-    Output<Buffer<float>> proxL1_input{"proxL1_input", 4};
+    Output<Buffer<float, 4>> proxL1_input{"proxL1_input"};
 
     void generate() {
         Expr width = input.width();

--- a/proximal/halide/src/prox_L1.cpp
+++ b/proximal/halide/src/prox_L1.cpp
@@ -27,6 +27,7 @@ public:
         if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
             proxL1_input.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
+            theta.set_estimate(1.0f);
             return;
         }
         // Schedule

--- a/proximal/halide/src/prox_L1.cpp
+++ b/proximal/halide/src/prox_L1.cpp
@@ -24,7 +24,7 @@ public:
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
             proxL1_input.set_estimates({{0, 512}, {0, 512}, {0, 1}, {0, 2}});
             return;

--- a/proximal/halide/src/prox_Poisson.cpp
+++ b/proximal/halide/src/prox_Poisson.cpp
@@ -32,6 +32,7 @@ class proxPoisson_gen : public Generator<proxPoisson_gen> {
             M.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             b.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             output.set_estimates({{0, 512}, {0, 512}, {0, 1}});
+            theta.set_estimate(1.0f);
             return;
         }
 

--- a/proximal/halide/src/prox_Poisson.cpp
+++ b/proximal/halide/src/prox_Poisson.cpp
@@ -10,12 +10,12 @@ using namespace Halide::BoundaryConditions;
 
 class proxPoisson_gen : public Generator<proxPoisson_gen> {
    public:
-    Input<Buffer<float>> input{"input", 3};
-    Input<Buffer<float>> M{"M", 3};
-    Input<Buffer<float>> b{"b", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Input<Buffer<float, 3>> M{"M"};
+    Input<Buffer<float, 3>> b{"b"};
     Input<float> theta{"theta"};
 
-    Output<Buffer<float>> output{"output", 3};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         // Inputs

--- a/proximal/halide/src/prox_Poisson.cpp
+++ b/proximal/halide/src/prox_Poisson.cpp
@@ -27,7 +27,7 @@ class proxPoisson_gen : public Generator<proxPoisson_gen> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             input.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             M.set_estimates({{0, 512}, {0, 512}, {0, 1}});
             b.set_estimates({{0, 512}, {0, 512}, {0, 1}});

--- a/proximal/halide/src/user-problem/linearized-admm-gen.cpp
+++ b/proximal/halide/src/user-problem/linearized-admm-gen.cpp
@@ -10,18 +10,18 @@ class LinearizedADMMIter : public Generator<LinearizedADMMIter> {
 
    public:
     /** User-provided distorted, and noisy image. */
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
 
     /** Initial estimate of the restored image. */
-    Input<Buffer<float>> v{"v", 3};
+    Input<Buffer<float, 3>> v{"v"};
 
     // TODO(Antony): How do we determine the number of inputs z_i at run time? Generator::configure() ?
     // Does Buffer<Func[2]> results in terse code? How to set dimensions?
-    Input<Buffer<float>> z0{"z0", 4};
-    Input<Buffer<float>> z1{"z1", 3};
+    Input<Buffer<float, 4>> z0{"z0"};
+    Input<Buffer<float, 3>> z1{"z1"};
 
-    Input<Buffer<float>> u0{"u0", 4};
-    Input<Buffer<float>> u1{"u1", 3};
+    Input<Buffer<float, 4>> u0{"u0"};
+    Input<Buffer<float, 3>> u1{"u1"};
 
     /** Problem scaling factor.
      *
@@ -40,14 +40,14 @@ class LinearizedADMMIter : public Generator<LinearizedADMMIter> {
 
     /** Optimal solution, after a hard termination after iterating for n_iter
      * times. */
-    Output<Buffer<float>> v_new{"v_new", 3};
+    Output<Buffer<float, 3>> v_new{"v_new"};
 
     // TODO(Antony): How do we figure out the number of outputs z_i at run time? configure() ?
-    Output<Buffer<float>> z0_new{"z0_new", 4};
-    Output<Buffer<float>> z1_new{"z1_new", 3};
+    Output<Buffer<float, 4>> z0_new{"z0_new"};
+    Output<Buffer<float, 3>> z1_new{"z1_new"};
 
-    Output<Buffer<float>> u0_new{"u0_new", 4};
-    Output<Buffer<float>> u1_new{"u1_new", 3};
+    Output<Buffer<float, 4>> u0_new{"u0_new"};
+    Output<Buffer<float, 3>> u1_new{"u1_new"};
 
     // Convergence metrics
     Output<float> r{"r"};  //!< Primal residual
@@ -108,23 +108,29 @@ class LinearizedADMMIter : public Generator<LinearizedADMMIter> {
 
     /** Inform Halide of the fixed input and output image sizes. */
     void setBounds() {
-        for (auto* a : {&input, &v, &z0, &u0, &z1, &u1}) {
+        for (auto* a : {&input, &v, &z1, &u1}) {
             a->dim(0).set_bounds(0, W);
             a->dim(1).set_bounds(0, H);
             a->dim(2).set_bounds(0, 1);
         }
 
         for (auto* a : {&z0, &u0}) {
+            a->dim(0).set_bounds(0, W);
+            a->dim(1).set_bounds(0, H);
+            a->dim(2).set_bounds(0, 1);
             a->dim(3).set_bounds(0, 2);
         }
 
-        for (auto* a : {&v_new, &z0_new, &u0_new, &z1_new, &u1_new}) {
+        for (auto* a : {&v_new, &z1_new, &u1_new}) {
             a->dim(0).set_bounds(0, W);
             a->dim(1).set_bounds(0, H);
             a->dim(2).set_bounds(0, 1);
         }
 
         for (auto* a : {&z0_new, &u0_new}) {
+            a->dim(0).set_bounds(0, W);
+            a->dim(1).set_bounds(0, H);
+            a->dim(2).set_bounds(0, 1);
             a->dim(3).set_bounds(0, 2);
         }
     }

--- a/proximal/halide/src/user-problem/linearized-admm-gen.cpp
+++ b/proximal/halide/src/user-problem/linearized-admm-gen.cpp
@@ -142,7 +142,7 @@ class LinearizedADMMIter : public Generator<LinearizedADMMIter> {
     void schedule() {
         setBounds();
 
-        if (auto_schedule) {
+        if (using_autoscheduler()) {
             // Estimate the image sizes of the inputs.
             for (auto* a : {&input, &v, &z1, &u1}) {
                 a->set_estimates({{0, W}, {0, H}, {0, 1}});

--- a/proximal/halide/src/user-problem/meson.build
+++ b/proximal/halide/src/user-problem/meson.build
@@ -31,11 +31,13 @@ solver_bin = custom_target(
         '-o', meson.current_build_dir(),
         '-g', 'ladmm_iter',
         '-e', 'static_library,h,stmt_html',
-        'machine_params=12,6291000,40',
         'target=host',
-        'auto_schedule=true',
-        '-s','Mullapudi2016',
-        '-p','autoschedule_mullapudi2016',
+
+        '-p', 'autoschedule_mullapudi2016',
+        'autoscheduler=Mullapudi2016',
+        'autoscheduler.parallelism=4',
+        'autoscheduler.last_level_cache_size=6291000',
+        'autoscheduler.balance=40',
 
         'n_iter=1',     # number of ADMM iterations before checking convergence
         'mu=0.333',     # Problem scaling factor. Defaults to 1 / sqrt( || K || ).

--- a/proximal/halide/subprojects/halide-x86_64-darwin.wrap
+++ b/proximal/halide/subprojects/halide-x86_64-darwin.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = Halide-14.0.0-x86-64-osx
+directory = Halide-16.0.0-x86-64-osx
 
-source_url = https://github.com/halide/Halide/releases/download/v14.0.0/Halide-14.0.0-x86-64-osx-6b9ed2afd1d6d0badf04986602c943e287d44e46.tar.gz
-source_filename = Halide-14.0.0-x86-64-osx.tar.gz
-source_hash = 569b1cda858d278d9dd68e072768d8347775e419f2ff39ff34d001ceb299e3c4
+source_url = https://github.com/halide/Halide/releases/download/v16.0.0/Halide-16.0.0-x86-64-osx-1e963ff817ef0968cc25d811a25a7350c8953ee6.tar.gz
+source_filename = Halide-16.0.0-x86-64-osx.tar.gz
+source_hash = 618b179754e337ecd69e05f3e540be1f65ee8da491c394458b779f4fd9f3d14d
 
 patch_directory = halide
 

--- a/proximal/halide/subprojects/halide-x86_64-linux.wrap
+++ b/proximal/halide/subprojects/halide-x86_64-linux.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = Halide-14.0.0-x86-64-linux
+directory = Halide-16.0.0-x86-64-linux
 
-source_url = https://github.com/halide/Halide/releases/download/v14.0.0/Halide-14.0.0-x86-64-linux-6b9ed2afd1d6d0badf04986602c943e287d44e46.tar.gz
-source_filename = Halide-14.0.0-x86-64-linux.tar.gz
-source_hash = be3bdd067acb9ee0d37d0830821113cd69174bee46da466a836d8829fef7cf91
+source_url = https://github.com/halide/Halide/releases/download/v16.0.0/Halide-16.0.0-x86-64-linux-1e963ff817ef0968cc25d811a25a7350c8953ee6.tar.gz
+source_filename = Halide-16.0.0-x86-64-linux.tar.gz
+source_hash = 694b3ed359d694f82dca9ccca761d927fdf97599b78ef0afe2ad881669ae6c40
 
 patch_directory = halide
 

--- a/proximal/halide/subprojects/halide-x86_64-windows.wrap
+++ b/proximal/halide/subprojects/halide-x86_64-windows.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = Halide-14.0.0-x86-64-windows
+directory = Halide-16.0.0-x86-64-windows
 
-source_url = https://github.com/halide/Halide/releases/download/v14.0.0/Halide-14.0.0-x86-64-windows-6b9ed2afd1d6d0badf04986602c943e287d44e46.zip
-source_filename = Halide-14.0.0-x86-64-windows.zip
-source_hash = a7a0481af2691ec436d79c20ca441e9a701bfce409f4f763dab75a8f1d740179
+source_url = https://github.com/halide/Halide/releases/download/v16.0.0/Halide-16.0.0-x86-64-windows-1e963ff817ef0968cc25d811a25a7350c8953ee6.zip
+source_filename = Halide-16.0.0-x86-64-windows.zip
+source_hash = 603d1c1764a45c65fd233dd83201280612c8903d8a01757c503e4c2cc9094bd8
 
 patch_directory = halide
 

--- a/proximal/halide/subprojects/packagefiles/halide/meson.build
+++ b/proximal/halide/subprojects/packagefiles/halide/meson.build
@@ -1,5 +1,5 @@
 project('halide toolchain', 'cpp',
-    version: '14.0.0')
+    version: '16.0.0')
 
 cc = meson.get_compiler('cpp', native: true)
 

--- a/proximal/lin_ops/comp_graph.py
+++ b/proximal/lin_ops/comp_graph.py
@@ -430,4 +430,4 @@ def est_CompGraph_norm(K, tol=1e-3, try_fast_norm=True):
                        KtK, KtK)
 
     Knorm = np.sqrt(eigs(A, k=1, M=None, sigma=None, which='LM', tol=tol)[0].real)
-    return np.float(Knorm)
+    return float(Knorm)


### PR DESCRIPTION
Upgrade the Halide toolchain to 16.0. Call the new autoscheduler APIs. Specify parameters for each auto-scheduler.

Proximal functions require a regularization parameter to function, where `theta > 0`. The Anderson2021 algorithm optimizer (aka Halide auto-scheduler) requires a rough estimate of the `theta` value. Make it so.

