### PR TITLE
Resolve L-ADMM code generator error in clang14 toolchain

### DIFF
--- a/.github/workflows/compile-halide-cpp.yml
+++ b/.github/workflows/compile-halide-cpp.yml
@@ -43,18 +43,20 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install meson ninja
 
+    - name: Cache 3rd party C++ projects
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-meson-cache
+        path: proximal/halide/subprojects/packagecache/
+
     - name: Resolve C++ build dependencies
       run: meson setup proximal/halide proximal/halide/build
     
     - name: Build ProxImaL-codegen
       run: ninja -C proximal/halide/build ladmm-runtime
-      # TODO(Antony): Resolve z-update error in MacOS-clang14 toolchain
-      if: startsWith(matrix.os, 'macos') == false
 
     - name: Build Python interfaces
       run: ninja -C proximal/halide/build python_interface
 
     - name: Run test suite
       run: ninja -C proximal/halide/build test
-      # TODO(Antony): Resolve z-update error in MacOS-clang14 toolchain
-      if: startsWith(matrix.os, 'macos') == false

--- a/.github/workflows/compile-halide-cpp.yml
+++ b/.github/workflows/compile-halide-cpp.yml
@@ -54,9 +54,13 @@ jobs:
     
     - name: Build ProxImaL-codegen
       run: ninja -C proximal/halide/build ladmm-runtime
+      # TODO(Antony): Resolve "missing DLLs" in Windows Docker environment.
+      if: startsWith(matrix.os, 'window') == false
 
     - name: Build Python interfaces
       run: ninja -C proximal/halide/build python_interface
+      if: startsWith(matrix.os, 'window') == false
 
     - name: Run test suite
       run: ninja -C proximal/halide/build test
+      if: startsWith(matrix.os, 'window') == false


### PR DESCRIPTION
Resolves #72 by implementing L-ADMM's z-update via `ranges::transform()` instead of ranged for-loop.  