### PR TITLE
Compute residuals with C++20 ranges::transform

### DIFF
--- a/proximal/halide/src/algorithm/linearized-admm.h
+++ b/proximal/halide/src/algorithm/linearized-admm.h
@@ -14,7 +14,7 @@ using ranges::zip_view;
 
 namespace utils {
 inline Expr
-norm(const Func& v, const RDom r) {
+norm(const Func& v, const RDom& r) {
     // TODO(Antony): n_channels.
     if (v.dimensions() == 4) {
         return sqrt(sum(v(r.x, r.y, r.z, r.w) * v(r.x, r.y, r.z, r.w)));
@@ -25,11 +25,12 @@ norm(const Func& v, const RDom r) {
 
 template <size_t N>
 inline Expr
-norm(const FuncTuple<N>& v, const RDom r) {
-    Expr s = 0;
+norm(const FuncTuple<N>& v, const RDom& r) {
+    Expr s = 0.0f;
 
     // TODO(Antony): item specific n-dimensions
-    for (auto&& _v : v) {
+    // Bug: Segfault here.
+    for (const auto& _v : v) {
         if (_v.dimensions() == 4) {
             s += sum(_v(r.x, r.y, r.z, r.w) * _v(r.x, r.y, r.z, r.w));
         } else {  // n_dim == 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ meson==0.58.1
 numpy
 scipy
 cvxpy
-numexpr
+numexpr==2.8.4
 opencv-python
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-cov
 pillow
-meson==0.58.1
+meson==1.2.1
 numpy
 scipy
 cvxpy

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='http://github.com/comp-imaging/ProxImaL/',
     install_requires=["numpy >= 1.9",
                       "scipy >= 0.15",
-                      "numexpr",
+                      "numexpr <= 2.8.4",
                       "Pillow",
                       "meson >= 0.58"],
 )


### PR DESCRIPTION
Refactor the code to compute the primal and dual residuals, such that the residual values is captured in the main Halide pipeline.

On clang14+MacOS of the Github CI server, we previously encountered a problem that the residual stage "r" is captured by r-value, so the expression for computing the residual was destroyed on the fly. We need
to capture the l-value reference instead. Hence the rewrite.

See also: #72 . 
