### PR TITLE
Avoid API breaking changes in Numexpr 2.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ meson==0.58.1
 numpy
 scipy
 cvxpy
-numexpr
+numexpr==2.8.4
 opencv-python
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='http://github.com/comp-imaging/ProxImaL/',
     install_requires=["numpy >= 1.9",
                       "scipy >= 0.15",
-                      "numexpr",
+                      "numexpr <= 2.8.4",
                       "Pillow",
                       "meson >= 0.58"],
 )


### PR DESCRIPTION
Fallback to Numexpr version 2.8.4, such that the keyword argument: `numexpr.evaluate(..., global_dict={})` can capture user defined global dictionary.

Resolves: #80 . 