### PR TITLE
Ensure fortran order when proximal cost function value is computed

### DIFF
--- a/proximal/examples/test_deconv.py
+++ b/proximal/examples/test_deconv.py
@@ -1,20 +1,17 @@
 # Proximal
 import sys
+
 sys.path.append('../../')
 
-from proximal.utils.utils import *
-from proximal.utils.metrics import *
-from proximal.halide.halide import *
-from proximal.lin_ops import *
-from proximal.prox_fns import *
-from proximal.algorithms import *
+from proximal.utils.utils import (get_test_image, get_kernel, Impl, tic, toc)
+from proximal.halide.halide import Halide
+from proximal import (conv, group_norm1, sum_squares, Problem, Variable, grad,
+                      cg_options)
 
 import numpy as np
 from scipy import ndimage
-from scipy.misc import ascent
 
 import matplotlib.pyplot as plt
-import cv2
 
 ############################################################
 
@@ -27,8 +24,7 @@ K = get_kernel(31, len(I.shape))
 
 # Generate observation
 sigma_noise = 0.01
-b = ndimage.convolve(I, K,
-                     mode='wrap')
+b = ndimage.convolve(I, K, mode='wrap')
 b += sigma_noise * np.random.randn(*I.shape)
 
 # Display data
@@ -52,36 +48,38 @@ lambda_tv = 1.0
 lambda_data = 500.0
 
 tic()
-Halide('fft2_r2c', target_shape=(WIDTH, WIDTH), recompile=True, reconfigure=True)
+Halide('fft2_r2c',
+       target_shape=(WIDTH, WIDTH),
+       recompile=True,
+       reconfigure=True)
 Halide('ifft2_c2r', recompile=True)
-print('Halide compile time = {:.0f}ms'.format(toc()))
+print(f'Halide compile time = {toc():.0f}ms')
 
 x = Variable(I.shape)
 
 options = cg_options(tol=1e-4, num_iters=100, verbose=False)
 tic()
 
-solver_options = dict(
-    max_iters=300,
-    eps_abs=1e-2,
-    eps_rel=1e-2,
-    lin_solver_options=options,
-    metric=None,
-    verbose=True,
-)
+solver_options = {
+    'max_iters': 300,
+    'eps_abs': 1e-2,
+    'eps_rel': 1e-2,
+    'lin_solver_options': options,
+    'metric': None,
+    'verbose': True,
+}
 
 hl = Impl['halide']
 
 prob = Problem(
     sum_squares(conv(K, x, dims=2, implem=hl) - b) * lambda_data +
-    lambda_tv *
-    group_norm1(grad(x, dims=2, implem=hl), [2], implem=hl),
+    lambda_tv * group_norm1(grad(x, dims=2, implem=hl), [2], implem=hl),
     implem=hl,
     lin_solver='cg',
 )
 result = prob.solve(solver='ladmm', **solver_options)
 
-print('Overall solver took: {:.1f}ms; cost function = {}'.format(toc(), result))
+print(f'Overall solver took: {toc():.1f}ms; cost function = {result}')
 
 plt.subplot(224)
 imgplot = plt.imshow(x.value,

--- a/proximal/lin_ops/lin_op.py
+++ b/proximal/lin_ops/lin_op.py
@@ -209,7 +209,7 @@ class LinOp(object):
     def value(self):
         inputs = []
         for node in self.input_nodes:
-            inputs.append(node.value)
+            inputs.append(np.asfortranarray(node.value, dtype=np.float32))
         output = np.zeros(self.shape, dtype=np.float32, order='F')
         self.forward(inputs, [output])
         return output

--- a/proximal/prox_fns/prox_fn.py
+++ b/proximal/prox_fns/prox_fn.py
@@ -77,9 +77,8 @@ class ProxFn(object):
         """Wrapper on the prox function to handle alpha, etc.
            It is here the iteration for debug purposese etc.
         """
-
         if np.isscalar(v):
-            v = np.array([v])
+            v = np.array([v], order='F')
 
         if self.implementation == Impl['halide']:
             # To justify Halide-acceleration Prox function, explicit memory copy
@@ -88,7 +87,7 @@ class ProxFn(object):
             # than the pure Numpy/Numexpr implementation for small images.
             assert v.shape == self.lin_op.shape, "Buffer shape must match that of the linear operator"
             assert v.dtype is np.dtype(np.float32), "Buffer type must be float32"
-            assert np.isfortran(v), "Buffer data layout must be Fortran style"
+            assert v.flags.f_contiguous, "Buffer data layout must be Fortran style"
 
         symbols = {
             'rho': rho,


### PR DESCRIPTION
When the cost function is evaluated, ensure all constants and image buffers are in Fortran order. Otherwise, the Halide-accelerated modules will return data layout error. 