### PR TITLE
Cross-platform build support of non-local means algorithm

### DIFF
--- a/proximal/halide/interface/prox_NLM.cpp
+++ b/proximal/halide/interface/prox_NLM.cpp
@@ -1,0 +1,23 @@
+#include "proxNLM.h"
+#include "util.hpp"
+
+namespace proximal {
+
+int
+prox_NLM_glue(const array_float_t input, const float theta, const array_float_t params,
+              array_float_t output) {
+    auto input_buf = getHalideBuffer<3>(input);
+    auto params_buf = getHalideBuffer<1>(params);
+
+    auto output_buf = getHalideBuffer<3>(output, true);
+
+    const auto success = proxNLM(input_buf, theta, params_buf, output_buf);
+    output_buf.copy_to_host();
+    return success;
+}
+
+}  // namespace proximal
+
+PYBIND11_MODULE(prox_NLM, m) {
+    m.def("run", &proximal::prox_NLM_glue, "Denoise image with non-local means");
+}

--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -26,6 +26,10 @@ pipeline_src = [
     'src/At_warp.cpp',
 ]
 
+if get_option('build_nlm')
+    pipeline_src += 'src/prox_NLM.cpp'
+endif
+
 halide_generator = executable(
     'halide_pipelines',
     sources: pipeline_src,
@@ -106,6 +110,19 @@ python_dep = py.dependency()
 pybind11_dep = subproject('pybind11').get_variable('pybind11_dep')
 
 cuda_toolchain = find_program('nvcc', required: false)
+
+if get_option('build_nlm')
+    # Provides libnlm_extern.so
+    subdir('src/external')
+
+    pipeline_name += [[
+        'proxNLM',
+        ['prox_NLM'],
+        false,
+        [],
+    ]]
+endif
+
 
 if build_machine.system() == 'windows'
     env = { 'PATH': halide_library_path }

--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -43,67 +43,57 @@ generator_param = [
   'htarget=@0@'.format(get_option('htarget')),
 ]
 
-pipeline_name = [[
-        'convImg',
-        ['A_conv'],
-        true,
-        [],
-    ], [
-        'convImgT',
-        ['At_conv'],
-        true,
-        [],
-    ], [
-        'proxL1',
-        ['prox_L1'],
-        true,
-        [],
-    ], [
-        'proxIsoL1',
-        ['prox_IsoL1'],
-        true,
-        [],
-    ], [
-        'proxPoisson',
-        ['prox_Poisson'],
-        true,
-        [],
-    ], [
-        'fftR2CImg',
-        ['fft2_r2c'],
-        false,
-        generator_param,
-    ], [
-        'ifftC2RImg',
-        ['ifft2_c2r'],
-        false,
-        generator_param,
-    ], [
-        'gradTransImg',
-        ['At_grad'],
-        true,
-        [],
-    ], [
-        'gradImg',
-        ['A_grad'],
-        true,
-        [],
-    ], [
-        'WImg',
-        ['A_mask', 'At_mask'],
-        true,
-        [],
-    ], [
-        'warpImg',
-        ['A_warp'],
-        false,
-        [],
-    ], [
-        'warpImgT',
-        ['At_warp'],
-        false,
-        [],
-]]
+pipeline_name = [{
+        'name': 'convImg',
+        'interfaces': ['A_conv'],
+        'autoschedule': true,
+    }, {
+        'name': 'convImgT',
+        'interfaces': ['At_conv'],
+        'autoschedule': true,
+    }, {
+        'name': 'proxL1',
+        'interfaces': ['prox_L1'],
+        'autoschedule': true,
+    }, {
+        'name': 'proxIsoL1',
+        'interfaces': ['prox_IsoL1'],
+        'autoschedule': true,
+    }, {
+        'name': 'proxPoisson',
+        'interfaces': ['prox_Poisson'],
+        'autoschedule': true,
+    }, {
+        'name': 'fftR2CImg',
+        'interfaces': ['fft2_r2c'],
+        'autoschedule': false,
+        'generator_param': generator_param,
+    }, {
+        'name': 'ifftC2RImg',
+        'interfaces': ['ifft2_c2r'],
+        'autoschedule': false,
+        'generator_param': generator_param,
+    }, {
+        'name': 'gradTransImg',
+        'interfaces': ['At_grad'],
+        'autoschedule': true,
+    }, {
+        'name': 'gradImg',
+        'interfaces': ['A_grad'],
+        'autoschedule': true,
+    }, {
+        'name': 'WImg',
+        'interfaces': ['A_mask', 'At_mask'],
+        'autoschedule': true,
+    }, {
+        'name': 'warpImg',
+        'interfaces': ['A_warp'],
+        'autoschedule': false,
+    }, {
+        'name': 'warpImgT',
+        'interfaces': ['At_warp'],
+        'autoschedule': false,
+}]
 
 py = import('python').find_installation()
 python_dep = py.dependency()
@@ -115,12 +105,11 @@ if get_option('build_nlm')
     # Provides libnlm_extern.so
     subdir('src/external')
 
-    pipeline_name += [[
-        'proxNLM',
-        ['prox_NLM'],
-        false,
-        [],
-    ]]
+    pipeline_name += {
+        'name': 'proxNLM',
+        'interfaces': ['prox_NLM'],
+        'autoschedule': false,
+    }
 endif
 
 
@@ -140,20 +129,18 @@ foreach p : pipeline_name
     compile_cmd = [
         halide_generator,
         '-o', meson.current_build_dir(),
-        '-g', p[0],
+        '-g', p['name'],
         '-e', 'o,h',
     ]
 
-    auto_schedule = p[2]
-
-    if cuda_toolchain.found() and auto_schedule
+    if cuda_toolchain.found() and p['autoschedule']
         compile_cmd += [
             'target=host-cuda',
             '-p', 'autoschedule_li2018',
             'autoscheduler=Li2018',
             'autoscheduler.parallelism=32',
         ]
-    elif auto_schedule
+    elif p['autoschedule']
         compile_cmd += [
             'target=host',
             '-p', 'autoschedule_mullapudi2016',
@@ -171,27 +158,39 @@ foreach p : pipeline_name
         ]
     endif
 
+    if not p.has_key('generator_param')
+        p += {'generator_param': []}
+    endif
+
     obj = custom_target(
-        p[0] + '.[oh]',
+        p['name'] + '.[oh]',
         output: [
-            p[0] + '.' + object_file_ext,
-            p[0] + '.h',
+            p['name'] + '.' + object_file_ext,
+            p['name'] + '.h',
         ],
         input: halide_generator,
         env: env,
         command: [
             compile_cmd,
-            p[3],
+            p['generator_param'],
         ],
     )
 
-    foreach library_name : p[1]
+    if not p.has_key('link_with')
+        p += {'link_with': []}
+    endif
+
+    foreach library_name : p['interfaces']
         lib = py.extension_module(
             library_name,
             sources: [
                 'interface/@0@.cpp'.format(library_name),
                 obj,
             ],
+            cpp_args: [
+                '-fvisibility=hidden',
+            ],
+            link_with: p['link_with'],
             dependencies: [
                 python_dep,
                 pybind11_dep,

--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -109,6 +109,7 @@ if get_option('build_nlm')
         'name': 'proxNLM',
         'interfaces': ['prox_NLM'],
         'autoschedule': false,
+        'link_with': nlm_extern_lib,
     }
 endif
 

--- a/proximal/halide/meson_options.txt
+++ b/proximal/halide/meson_options.txt
@@ -1,2 +1,3 @@
 option('wtarget', type: 'integer', min: 2, max: 4096, value: 512)
 option('htarget', type: 'integer', min: 2, max: 4096, value: 512)
+option('build_nlm', type: 'boolean', value: false)

--- a/proximal/halide/src/external/external_NLM.cpp
+++ b/proximal/halide/src/external/external_NLM.cpp
@@ -11,14 +11,13 @@
 
 #include "static_image.h"
 
-#include <opencv2/cudaarithm.hpp>
 #include <opencv2/photo/cuda.hpp>
 #include <opencv2/photo.hpp>
 #include <opencv2/imgproc.hpp>
 
 using namespace std;
 using namespace cv;
-using namespace cv::cuda;
+using cv::cuda::GpuMat;
 
 extern "C" int NLM_extern(buffer_t * in, buffer_t * params, float sigma, int w, int h, int ch, buffer_t * out)
 {

--- a/proximal/halide/src/external/meson.build
+++ b/proximal/halide/src/external/meson.build
@@ -1,0 +1,14 @@
+if not cuda_toolchain.found()
+    error('cv::fastNlMeanDenoising needs cuda runtime to function.')
+endif
+
+nlm_extern_lib = library('nlm_extern',
+    sources: [
+        'external_NLM.cpp',
+    ],
+    dependencies: [
+        dependency('opencv4'),
+    ],
+)
+
+alias_target('nlm_extern', nlm_extern_lib)

--- a/proximal/halide/src/prox_NLM.cpp
+++ b/proximal/halide/src/prox_NLM.cpp
@@ -1,47 +1,56 @@
 ////////////////////////////////////////////////////////////////////////////////
-//NLM proximal operator from "core/prox_operators.h"
+// NLM proximal operator from "core/prox_operators.h"
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <Halide.h>
 
 using namespace Halide;
-using namespace Halide::BoundaryConditions;
 
 #include "core/prox_operators.h"
 
+namespace {
+
+constexpr auto n_params = 4;
+
 class proxNLM_extern_gen : public Generator<proxNLM_extern_gen> {
-public:
+   public:
+    Input<Buffer<float, 3>> input{"input"};
+    Input<float> theta{"theta"};
+    Input<Buffer<float, 1>> params{"params"};
 
-    ImageParam input{Float(32), 3, "input"};
-    Param<float> theta{"theta"};
-    ImageParam params{Float(32), 2, "params"};
+    Output<Buffer<float, 3>> output{"output"};
 
-    Func build() {
+    void generate() {
+        const Expr width = input.width();
+        const Expr height = input.height();
+        const Expr channels = input.channels();
 
-        Expr width = input.width();
-        Expr height = input.height();
-        Expr channels = input.channels();
-     
-        //Get input and reshuffle
-        Func input_func("input_func");
-        input_func(x, y, c) = input(x, y, c);
-        
-        //Params
-        Func params_func("param_func");
-        params_func(k) = params(0,k);
+        // Schedule
+        Func NLM_input{"NLM_input"};
+        output = proxNLM(input, theta, params, width, height, channels);
 
-        //Schedule
-        Func NLM_input("NLM_input");
-        NLM_input = proxNLM(input_func, theta, params_func, width, height, channels);
-        NLM_input.compute_root();
+        input.dim(0).set_min(0).set_stride(1);
+        input.dim(1).set_min(0).set_stride(width);
+        input.dim(2).set_min(0).set_stride(width * height);
 
-        //Allow for arbitrary strides
-        input.set_stride(0, Expr());
-        params.set_stride(0, Expr());
-        NLM_input.output_buffer().set_stride(0, Expr()); 
-        
-        return NLM_input;
+        params.dim(0).set_bounds(0, n_params);
+
+        output.dim(0).set_bounds(0, width).set_stride(1);
+        output.dim(1).set_bounds(0, height).set_stride(width);
+        output.dim(2).set_bounds(0, channels).set_stride(width * height);
+    }
+
+    void schedule() {
+        if (using_autoscheduler()) {
+            input.set_estimates({{0, 512}, {0, 512}, {0, 1}});
+            output.set_estimates({{0, 512}, {0, 512}, {0, 1}});
+            params.set_estimates({{0, n_params}});
+            theta.set_estimate(1.0f);
+            return;
+        }
     }
 };
 
-auto proxNLMextern = RegisterGenerator<proxNLM_extern_gen>("proxNLM_extern_gen");
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(proxNLM_extern_gen, proxNLM);


### PR DESCRIPTION
Scan the native (Linux) system for the OpenCV library. Compile `extern_NLM` as a dynamic library. Modernize the Halide-C++ interface that calls the `extern_NLM` function.

Todo: 

1. [x] generate Halide-accelerated code of the `proxNLM` function.
2. [x] Expose the function as a Python interface.
3. [ ] Enable cuda toolchain in Github CI; validate the build logic in a generic Linux OS.

Reference: #43 . 