### PR TITLE
Cache the Fourier transformed raw pixel image

### DIFF
--- a/proximal/algorithms/linearized_admm.py
+++ b/proximal/algorithms/linearized_admm.py
@@ -97,9 +97,11 @@ def solve(psi_fns, omega_fns, lmb=1.0, mu=None, quad_funcs=None,
         ne.evaluate('v_prev - (mu / lmb) * v', out=v, casting='unsafe')
 
         if len(omega_fns) > 0:
+            prox_log[omega_fns[0]].tic()
             v_shape = omega_fns[0].lin_op.shape
             v[:] = omega_fns[0].prox(1.0 / mu, np.asfortranarray(v.reshape(v_shape)), x_init=v_prev.copy(),
                                      lin_solver=lin_solver, options=lin_solver_options).ravel()
+            prox_log[omega_fns[0]].toc()
 
         # Update z.
         K.forward(v, Kv)

--- a/proximal/halide/interface/prox_L2.cpp
+++ b/proximal/halide/interface/prox_L2.cpp
@@ -11,8 +11,13 @@ prox_L2_glue(const array_float_t input, const float theta, const array_float_t o
     auto freq_diag_buf = getHalideComplexBuffer<4>(freq_diag);
     auto output_buf = getHalideBuffer<3>(output, true);
 
-    const auto success = least_square_direct(input_buf, theta, offset_buf,
-                                             freq_diag_buf, output_buf);
+    // A hash to denote when the Fourier transformed offset signal should be
+    // recomputed. TODO(Antony): It is more practical to marshal the
+    // proximal.Problem instance hash from Python runtime to here.
+    const auto offset_buf_hash = reinterpret_cast<uintptr_t>(offset_buf.begin());
+
+    const auto success = least_square_direct(input_buf, theta, offset_buf, freq_diag_buf,
+                                             offset_buf_hash, output_buf);
     output_buf.copy_to_host();
     return success;
 }

--- a/proximal/halide/interface/prox_L2_ignore_offset.cpp
+++ b/proximal/halide/interface/prox_L2_ignore_offset.cpp
@@ -13,8 +13,10 @@ prox_L2_ignore_offset_glue(const array_float_t input,
     constexpr float dont_care = 0;
     auto& dont_care_buf = input_buf;
 
-    const auto success = least_square_direct_ignore_offset(input_buf, dont_care, dont_care_buf,
-                                             freq_diag_buf, output_buf);
+    const uint64_t dont_care_hash = 0;
+
+    const auto success = least_square_direct_ignore_offset(
+        input_buf, dont_care, dont_care_buf, freq_diag_buf, dont_care_hash, output_buf);
     output_buf.copy_to_host();
     return success;
 }


### PR DESCRIPTION
In the direct Fourier method, the input raw image is converted to the Fourier space multiple times. Use the Halide's cache mechanism to elimate such a redundant compute.

The current PR doesn't cache `Kt * b = conv2d[h, b] =  F^T D * F * b` though. To be done in the next PR.

See also: #12 .