### PR TITLE
Compile Halide optimized pipelines on ARM64-Darwin environment

### DIFF
--- a/proximal/halide/src/user-problem/meson.build
+++ b/proximal/halide/src/user-problem/meson.build
@@ -65,6 +65,7 @@ test_runtime_exe = executable('test-ladmm-runtime',
     ],
     cpp_args: [
         '-DRAW_IMAGE_PATH="@0@"'.format(parrot_img),
+	'-DHALIDE_NO_JPEG',
     ],
     link_with: ladmm_runtime_lib,
     dependencies: [

--- a/proximal/halide/subprojects/halide-aarch64-darwin.wrap
+++ b/proximal/halide/subprojects/halide-aarch64-darwin.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = Halide-16.0.0-arm-64-osx
+
+source_url = https://github.com/halide/Halide/releases/download/v16.0.0/Halide-16.0.0-arm-64-osx-1e963ff817ef0968cc25d811a25a7350c8953ee6.tar.gz
+source_filename = Halide-16.0.0-arm-64-osx.tar.gz
+source_hash = 57e9b1de3a40d50a47e5f728aa12d838471c3c69cb250babf84999577f1e4d51
+
+patch_directory = halide
+
+


### PR DESCRIPTION
Add a warp file to describe where to download the Halide toolchain for MacOS OS on ARM64 processors. Exclude jpeg encoder and dependency requirement.

Use cases: latest Macbook computers having M1/M2 processors.

cc'ed @shnaqvi . 