### PR TITLE
Cache Ktb in least_square

### DIFF
--- a/proximal/utils/memoized_expr.py
+++ b/proximal/utils/memoized_expr.py
@@ -1,0 +1,16 @@
+import numpy as np
+import numexpr as ne
+
+class memoized_expr:
+    ''' Deferred computation of elementwise operations. '''
+
+    def __init__(self, expr: str, variables: dict, shape: list):
+        self.expr = expr
+        self.local_dict = variables
+        self.shape = shape 
+
+    def evaluate(self) -> np.array:
+        out = np.empty(self.shape, dtype=np.float32, order='F')
+        ne.evaluate(self.expr, self.local_dict, casting='unsafe', out=out)
+
+        return out


### PR DESCRIPTION
Retrieve the pointer address of the offset buffer as hash. Pre-compute and cache the value of Ktb. Implement the feature `memoized_expr` to delay computation of `offset + b` in least_square.prox() function.

On average, it cuts ~30% execution time per call (860ms -> 600ms) to `least_square.prox()` on x86_64 CPU having 8 logical cores.

TODO(Antony): Too many level of caches already (`Ktb` in Numpy and `F_Ktb` in Halide). Eliminate all upstream caches.

Resolves: #12 .