### PR TITLE
Hotfix: `least_square.solve()` not accepting numpy

### DIFF
--- a/proximal/algorithms/admm.py
+++ b/proximal/algorithms/admm.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 from proximal.lin_ops import CompGraph, scale, vstack
 from proximal.utils.timings_log import TimingsLog, TimingsEntry
+from proximal.utils.memoized_expr import memoized_expr
 from .invert import get_least_squares_inverse, get_diag_quads
 import numpy as np
 import numexpr as ne
@@ -86,7 +87,8 @@ def solve(psi_fns, omega_fns, rho=1.0,
 
         # Update v.
         tmp = np.hstack([z - u] + const_terms)
-        v = v_update.solve(tmp, x_init=v, lin_solver=lin_solver, options=lin_solver_options)
+        tmp_expr = memoized_expr('tmp', {'tmp': tmp}, tmp.shape)
+        v = v_update.solve(tmp_expr, x_init=v, lin_solver=lin_solver, options=lin_solver_options)
 
         # Update z.
         K.forward(v, Kv)

--- a/proximal/algorithms/half_quadratic_splitting.py
+++ b/proximal/algorithms/half_quadratic_splitting.py
@@ -3,6 +3,7 @@ import numpy as np
 import math
 from proximal.lin_ops import CompGraph, scale, vstack
 from proximal.utils.timings_log import TimingsLog, TimingsEntry
+from proximal.utils.memoized_expr import memoized_expr
 from .invert import get_least_squares_inverse, get_diag_quads
 
 
@@ -110,7 +111,8 @@ def solve(psi_fns, omega_fns,
             # Update x.
             x_prev[:] = x
             tmp = np.hstack([w] + [cterm / np.sqrt(rho) for cterm in const_terms])
-            x = x_update.solve(tmp, x_init=x, lin_solver=lin_solver, options=lin_solver_options)
+            tmp_expr = memoized_expr('tmp', {'tmp': tmp}, tmp.shape)
+            x = x_update.solve(tmp_expr, x_init=x, lin_solver=lin_solver, options=lin_solver_options)
 
             # Very basic convergence check.
             r_x = np.linalg.norm(x_prev - x)


### PR DESCRIPTION
(The recent PR #97 broke the solvers. I am drafting a PR to fix it.)

In HQS and ADMM algorithms, disable the cache mechanism by passing new values to the `least_square.solve()` function.

When `px.Problem()` call is bypassed in the python unit tests, the cache_miss detection mechanism fails. Design a new hash/eviction key to ensure `Ktb` recompute.


