### PR TITLE
ProxImaLGen: Unroll the L-ADMM algorithm by N-times

### DIFF
--- a/proximal/halide/src/user-problem/linearized-admm-gen.cpp
+++ b/proximal/halide/src/user-problem/linearized-admm-gen.cpp
@@ -80,13 +80,15 @@ class LinearizedADMMIter : public Generator<LinearizedADMMIter> {
         const RDom output_dimensions{0, output_width, 0, output_height, 0, 1, 0, 2};
 
         for (size_t i = 0; i < n_iter; i++) {
+            const Func& v_prev =
+                (i == 0) ? v : v_list[i - 1];
             const FuncTuple<psi_size>& z_prev =
                 (i == 0) ? FuncTuple<psi_size>{z0, z1} : z_list[i - 1];
             const FuncTuple<psi_size>& u_prev =
                 (i == 0) ? FuncTuple<psi_size>{u0, u1} : u_list[i - 1];
 
             std::tie(v_list[i], z_list[i], u_list[i]) = algorithm::linearized_admm::iterate(
-                v, z_prev, u_prev, K, omega_fn, psi_fns, lmb, mu, input);
+                v_prev, z_prev, u_prev, K, omega_fn, psi_fns, lmb, mu, input);
         }
 
         const auto& z_prev = (n_iter > 1) ? *(z_list.rbegin() + 1) : FuncTuple<psi_size>{z0, z1};

--- a/proximal/halide/src/user-problem/meson.build
+++ b/proximal/halide/src/user-problem/meson.build
@@ -18,6 +18,14 @@ solver_generator = executable(
     ],
 )
 
+if host_machine.system() == 'darwin'
+    halide_target = 'host-metal' 
+    metal_dep = dependency('appleframeworks', modules: ['Metal', 'Foundation'])
+else
+    halide_target = 'host'
+    metal_dep = []
+endif
+
 solver_bin = custom_target(
     'ladmm_iter.[ah]',
     output: [
@@ -31,7 +39,7 @@ solver_bin = custom_target(
         '-o', meson.current_build_dir(),
         '-g', 'ladmm_iter',
         '-e', 'static_library,h,stmt_html',
-        'target=host',
+        'target=' + halide_target,
 
         '-p', 'autoschedule_mullapudi2016',
         'autoscheduler=Mullapudi2016',
@@ -51,7 +59,10 @@ ladmm_runtime_lib = library('ladmm-runtime',
         'ladmm-runtime.cpp',
         solver_bin,
     ],
-    dependencies: halide_runtime_dep,
+    dependencies: [
+      metal_dep,
+      halide_runtime_dep,
+    ],
 )
 
 libpng_dep = dependency('libpng', required: false)


### PR DESCRIPTION
Execute N iterations of the L-ADMM algorithm before checking the convergence criteria. Use previous value of `v`. Generate baremetal Halide/C++ code to run on machines without Python.

For MacOS execution environment, detect the presence of the Metal Shading Language (MSL) interface. Make it compulsory for generating the baremetal L-ADMM algorithm in MacOS, but don't use meta. to comupte (yet). 
