### PR TITLE
Validate halide build on Windows

### DIFF
--- a/.github/workflows/compile-halide-cpp.yml
+++ b/.github/workflows/compile-halide-cpp.yml
@@ -16,27 +16,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
-        # TODO(Antony): add Python 3.9 to test the Meson build system support
-        python-version: [3.8]
+        python-version: ["3.10"]
 
     steps:
     - name: Fetch sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
 
     - name: Install gcc toolchain
       run: sudo apt-get install build-essential
       if: startsWith(matrix.os, 'ubuntu') == true
-
-    - name: Install MSVC toolchain
-      uses: bus1/cabuild/action/msdevshell@v1
-      with:
-        architecture: x64
-      if: startsWith(matrix.os, 'windows') == true
 
     - name: Install Python dependencies
       run: |
@@ -49,18 +43,19 @@ jobs:
         key: ${{ runner.os }}-meson-cache
         path: proximal/halide/subprojects/packagecache/
 
-    - name: Resolve C++ build dependencies
+    - name: Resolve C++ build dependencies (non-Windows)
       run: meson setup proximal/halide proximal/halide/build
-    
-    - name: Build ProxImaL-codegen
-      run: ninja -C proximal/halide/build ladmm-runtime
-      # TODO(Antony): Resolve "missing DLLs" in Windows Docker environment.
       if: startsWith(matrix.os, 'window') == false
+    
+    - name: Resolve C++ build dependencies (msvc toolchain)
+      run: meson setup --vsenv proximal/halide proximal/halide/build
+      if: startsWith(matrix.os, 'window') == true
+
+    - name: Build ProxImaL-codegen
+      run: meson compile -C proximal/halide/build ladmm-runtime:alias
 
     - name: Build Python interfaces
-      run: ninja -C proximal/halide/build python_interface
-      if: startsWith(matrix.os, 'window') == false
+      run: meson compile -C proximal/halide/build python_interface
 
     - name: Run test suite
-      run: ninja -C proximal/halide/build test
-      if: startsWith(matrix.os, 'window') == false
+      run: meson test -C proximal/halide/build --suite codegen

--- a/proximal/halide/meson.build
+++ b/proximal/halide/meson.build
@@ -125,9 +125,11 @@ if get_option('build_nlm')
     }
 endif
 
-
 if build_machine.system() == 'windows'
-    env = { 'PATH': halide_library_path }
+    env = { 'PATH': [
+        halide_toolchain.get_variable('halide_dll_path'),
+        halide_library_path,
+    ]}
     object_file_ext = 'obj'
     statlib_file_ext = 'lib'
 else

--- a/proximal/halide/src/user-problem/meson.build
+++ b/proximal/halide/src/user-problem/meson.build
@@ -32,13 +32,13 @@ solver_bin = custom_target(
         'ladmm_iter.' + statlib_file_ext,
         'ladmm_iter.h',
     ],
-    input: solver_generator,
     env: env,
+    input: solver_generator,
     command: [
         solver_generator,
         '-o', meson.current_build_dir(),
         '-g', 'ladmm_iter',
-        '-e', 'static_library,h,stmt_html',
+        '-e', 'static_library,h',
         'target=' + halide_target,
 
         '-p', 'autoschedule_mullapudi2016',

--- a/proximal/halide/subprojects/packagefiles/halide/meson.build
+++ b/proximal/halide/subprojects/packagefiles/halide/meson.build
@@ -7,9 +7,12 @@ halide_inc = include_directories('include')
 
 if build_machine.system() == 'windows'
     halide_library_path = meson.current_source_dir() / 'lib/Release'
+    # Halide.dll is in a different path, why?
+    halide_dll_path = meson.current_source_dir() / 'bin/Release'
 else
     halide_library_path = meson.current_source_dir() / 'lib'
 endif
+
 halide_lib = cc.find_library('Halide', dirs: halide_library_path)
 
 halide_generator_dep = declare_dependency(


### PR DESCRIPTION
Configure meson build system to scan for msvc compiler toolchain. Compile everything. Run unit tests.