### PR TITLE
Lock to Numpy version 1.23

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,20 +15,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+
+    # UV is the pip accelerator.
     - name: Install dependencies
       run: |
         sudo apt-get install build-essential
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest ninja
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install --upgrade uv
+        uv pip install --system flake8 pytest
+        uv pip install --system -r requirements.txt
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -37,5 +42,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python setup.py install
+        uv pip install --system .
         pytest proximal/tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 pytest
 pytest-cov
 pillow
-meson==1.2.1
-numpy
+meson==1.5.0
+numpy==1.23.0
 scipy
 cvxpy
 numexpr==2.8.4
 opencv-python
 matplotlib
+ninja

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
                       'subprojects/packagefiles/halide/meson.build',
                       'meson.build']},
     url='http://github.com/comp-imaging/ProxImaL/',
-    install_requires=["numpy >= 1.9",
+    install_requires=["numpy <= 1.23.0",
                       "scipy >= 0.15",
                       "numexpr <= 2.8.4",
                       "Pillow",


### PR DESCRIPTION
Numpy 2.0 introduces a few breaking changes to Numexpr. Provide adhoc fix by locking to Numpy version 1.23.0

Use uv to speed up pip install. Cache downlaoded wheels. 