### PR TITLE
Update flake8 rules

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,15 +31,13 @@ jobs:
       run: |
         sudo apt-get install build-essential
         pip install --upgrade uv
-        uv pip install --system flake8 pytest
+        echo -e 'ruff\npytest\n' >> requirements.txt
         uv pip install --system -r requirements.txt
 
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        ruff check proximal
     - name: Test with pytest
       run: |
         uv pip install --system .

--- a/proximal/examples/test_matengine.py
+++ b/proximal/examples/test_matengine.py
@@ -43,4 +43,4 @@ plt.show()
 eng.quit()
 
 # Wait until done
-raw_input("Press Enter to continue...")
+input("Press Enter to continue...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.ruff]
+line-length=127
+
+[tool.ruff.lint]
+select=["E9", "F63", "F7", "F82", "C90"]
+
+[tool.ruff.lint.mccabe]
+max-complexity=30


### PR DESCRIPTION
Ensure flake8 rules are enabled on the CI runner. Use `ruff` to accelerate flake8 checking. Increase the McCabe max complexity score from 15 to 30 because `proximal/algorithms/pock_chambolle.py` contains `pycuda` code. 