### PR TITLE
Direct FFT method: resolve image boundary condition

### DIFF
--- a/proximal/halide/halide.py
+++ b/proximal/halide/halide.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # Includes
 import importlib
 import subprocess
@@ -7,7 +5,7 @@ import os
 import numpy as np
 
 
-class Halide(object):
+class Halide:
 
     def __init__(self,
                  func: str,
@@ -97,10 +95,11 @@ class Halide(object):
         if self.module_name[:4] == 'fft2':
             expected_shape = (launch.htarget, launch.wtarget)
             if np.any(expected_shape != self.target_shape):
-                print('Warning: FFT2 shape mismatch. Expected {expected_shape}, found {self.target_shape}. Please recompile.')
+                print(f'Warning: FFT2 shape mismatch. Expected {expected_shape}, found {self.target_shape}. Please recompile.')
 
             if np.any(expected_shape != args[0].shape):
-                print('Warning: Input image shape mismatch for FFT2. Expected {expected_shape}, found {self.args[0].shape}. Applying circular boundary condition.')
+                print('Warning: Input image shape mismatch for FFT2. '
+                      f'Expected {expected_shape}, found {args[0].shape}. Applying circular boundary condition.')
 
         error = launch.run(*args)
 

--- a/proximal/lin_ops/conv.py
+++ b/proximal/lin_ops/conv.py
@@ -38,8 +38,8 @@ class conv(LinOp):
                 output_fft_tmp = np.zeros((int((hsize[0] + 1) / 2) + 1, hsize[1], hsize[2]),
                                           dtype=np.complex64, order='F')
 
-                Halide('fft2_r2c', target_shape=hsize[:2]).fft2_r2c(self.kernel, int(self.kernel.shape[1] / 2),
-                                                int(self.kernel.shape[0] / 2), output_fft_tmp)
+                Halide('fft2_r2c', target_shape=hsize[:2]).fft2_r2c(self.kernel, self.kernel.shape[1] // 2,
+                                                self.kernel.shape[0] // 2, output_fft_tmp)
                 self.forward_kernel[:] = 0.
 
                 if len(arg.shape) == 2:

--- a/proximal/prox_fns/sum_squares.py
+++ b/proximal/prox_fns/sum_squares.py
@@ -229,7 +229,7 @@ class least_squares(sum_squares):
                         self.Ktb.reshape(self.freq_shape),
                         float(rho),
                         np.reshape(v, self.freq_shape),
-                        self.freq_diag,
+                        self.freq_diag.astype(np.complex64),
                         ftmp_halide_out,
                     )
 


### PR DESCRIPTION
When FFT's target width and height are larger than the image size, pad the space with zeros. Also, if shiftx and shifty are non-zeros, resolve the W-by-H tile with cyclic boundary condition.

Typical use-case:

```python
# Note the size difference between the input image and the blur kernel
input_image = np.empty((1024, 1024), dtype=np.float32, order='F')
blur_kernel = np.ones((3,3)) / 9.0
alpha = 1e-3

u = Variable((1024, 1024))
problem = Problem(
  sum_squares( conv(blur_kernel, u) - input_image ) + alpha * group_norm1( grad(u) ),
  implem='halide',
)

problem.solve()
```