### PR TITLE
Deprecate Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/compile-halide-cpp.yml
+++ b/.github/workflows/compile-halide-cpp.yml
@@ -34,8 +34,8 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install meson ninja
+        pip install --upgrade uv
+        uv pip install --system meson ninja
 
     - name: Cache 3rd party C++ projects
       uses: actions/cache@v3
@@ -46,7 +46,7 @@ jobs:
     - name: Resolve C++ build dependencies (non-Windows)
       run: meson setup proximal/halide proximal/halide/build
       if: startsWith(matrix.os, 'window') == false
-    
+
     - name: Resolve C++ build dependencies (msvc toolchain)
       run: meson setup --vsenv proximal/halide proximal/halide/build
       if: startsWith(matrix.os, 'window') == true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
         echo -e 'ruff\npytest\n' >> requirements.txt
         uv pip install --system -r requirements.txt
 
-    - name: Lint with flake8
+    - name: Lint with Ruff
       run: |
         # stop the build if there are Python syntax errors or undefined names
         ruff check proximal

--- a/proximal/halide/subprojects/pybind11.wrap
+++ b/proximal/halide/subprojects/pybind11.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
-directory = pybind11-2.6.1
-source_url = https://github.com/pybind/pybind11/archive/v2.6.1.tar.gz
-source_filename = pybind11-2.6.1.tar.gz
-source_hash = cdbe326d357f18b83d10322ba202d69f11b2f49e2d87ade0dc2be0c5c34f8e2a
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/pybind11/2.6.1/1/get_zip
-patch_filename = pybind11-2.6.1-1-wrap.zip
-patch_hash = 6de5477598b56c8a2e609196420c783ac35b79a31d6622121602e6ade6b3cee8
+directory = pybind11-2.13.5
+source_url = https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
+source_filename = pybind11-2.13.5.tar.gz
+source_hash = b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252
+patch_filename = pybind11_2.13.5-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pybind11_2.13.5-1/get_patch
+patch_hash = ecb031b830481560b3d8487ed63ba4f5509a074be42f5d19af64d844c795e15b
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/pybind11_2.13.5-1/pybind11-2.13.5.tar.gz
+wrapdb_version = 2.13.5-1
 
 [provide]
 pybind11 = pybind11_dep
-

--- a/proximal/prox_fns/prox_fn.py
+++ b/proximal/prox_fns/prox_fn.py
@@ -98,18 +98,18 @@ class ProxFn(object):
             'b': self.b.reshape(v.shape),
         }
 
-        rho_hat = ne.evaluate('(rho + 2 * gamma) / (alpha * beta**2)', global_dict=symbols)
+        rho_hat = ne.evaluate('(rho + 2 * gamma) / (alpha * beta**2)', symbols)
 
         ne.evaluate('(v * rho - c) * beta / (rho + 2 * gamma) -b',
-            global_dict=symbols, out=v, casting='unsafe')
+            symbols | {'v': v}, out=v, casting='unsafe')
 
         xhat = self._prox(rho_hat, v, *args, **kwargs)
         ne.evaluate('(xhat + b) / beta',
-            global_dict=symbols, out=xhat, casting='unsafe')
+            symbols | {'xhat': xhat}, out=xhat, casting='unsafe')
 
         if v.size == 1:
             return xhat[0]
-            
+
         return xhat
 
     def cuda_additional_buffers(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.ruff]
 line-length=127
+target-version="py310"
 
 [tool.ruff.lint]
 select=["E9", "F63", "F7", "F82", "C90"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ pytest
 pytest-cov
 pillow
 meson==1.5.0
-numpy==1.23.0
+numpy==1.26.0
 scipy
 cvxpy
-numexpr==2.8.5
+numexpr==2.10.1
 opencv-python
 matplotlib
 ninja

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
                       'subprojects/packagefiles/halide/meson.build',
                       'meson.build']},
     url='http://github.com/comp-imaging/ProxImaL/',
-    install_requires=["numpy <= 1.23.0",
+    install_requires=["numpy <= 1.26.0",
                       "scipy >= 0.15",
-                      "numexpr <= 2.8.5",
+                      "numexpr <= 2.10.1",
                       "Pillow",
                       "meson >= 0.58"],
 )


### PR DESCRIPTION
Require Python 3.10 or above to take advantage of new Dict merging syntax `|`. Do not use argument `global_dict` whenever we compile an Numexpr expression. Resolves Numexpr missing variables error.