### PR TITLE
Hotfix: Define proximal functions via `theta = 1/rho`

### DIFF
--- a/proximal/halide/src/algorithm/linearized-admm.h
+++ b/proximal/halide/src/algorithm/linearized-admm.h
@@ -153,7 +153,7 @@ computeConvergence(const Func& v, const FuncTuple<N>& z, const FuncTuple<N>& u,
 
     const Func Kv_norm = normSquared(Kv, output_dimensions);
     const Func z_norm = normSquared(z, output_dimensions);
-    const Expr eps_pri = eps_rel * sqrt(max(Kv_norm(), z_norm())) + output_size * eps_abs;
+    const Expr eps_pri = eps_rel * sqrt(max(Kv_norm(), z_norm())) + std::sqrt(float(output_size)) * eps_abs;
 
     const Func KTu_norm = normSquared(KTu, input_dimensions);
     const Expr eps_dual =

--- a/proximal/halide/src/core/prox_operators.h
+++ b/proximal/halide/src/core/prox_operators.h
@@ -52,8 +52,9 @@ proxL1(Func input, Expr width, Expr height, Expr theta) {
 
 Func
 proxSumsq(const Func& input, const Expr theta, const std::string&& name = "xhat") {
+    const Expr rho = 1.0f / theta;
     Func output{name};
-    output(x, y, c) = input(x, y, c) * theta / (theta + 2);
+    output(x, y, c) = input(x, y, c) * rho / (rho + 2);
 
     return output;
 }

--- a/proximal/halide/src/core/prox_parameterized.h
+++ b/proximal/halide/src/core/prox_parameterized.h
@@ -77,7 +77,10 @@ struct ParameterizedProx {
     Func operator()(const Func& v, const Expr& rho,
                     const std::optional<Func> _b = std::nullopt) const {
         const auto [v_hat, rho_hat] = forward(v, rho, _b);
-        const Func u_hat = prox(v_hat, rho_hat);
+
+        // Note(Antony): In `halide/core/prox_operators.h`, all proximal functions are defined as
+        // theta = 1 / rho. Make it so.
+        const Func u_hat = prox(v_hat, 1.0f / rho_hat);
         return backward(u_hat, _b);
     }
 };

--- a/proximal/halide/src/user-problem/meson.build
+++ b/proximal/halide/src/user-problem/meson.build
@@ -48,8 +48,8 @@ solver_bin = custom_target(
         'autoscheduler.balance=40',
 
         'n_iter=1',     # number of ADMM iterations before checking convergence
-        'mu=0.333',     # Problem scaling factor. Defaults to 1 / sqrt( || K || ).
-        'lmb=3.0',      # Problem scaling factor. Defaults to sqrt( || K || ).
+        'mu=0.11111',     # Problem scaling factor. Defaults to 1 / sqrt( || K || ).
+        'lmb=1.0',      # Problem scaling factor. Defaults to sqrt( || K || ).
     ],
     build_by_default: true,
 )

--- a/proximal/halide/src/user-problem/problem-definition.h
+++ b/proximal/halide/src/user-problem/problem-definition.h
@@ -83,7 +83,7 @@ const std::array<ParameterizedProx, problem_config::psi_size> psi_fns{
 
                           return proxIsoL1(u, output_width, output_height, theta);
                       },
-                      /* .alpha = */ 0.1f,
+                      /* .alpha = */ 5e-2f,
                       /* .beta = */ 1.0f,
                       /* .gamma = */ 0.0f,
                       /* ._c = */ 0.0f,


### PR DESCRIPTION
Halide-accelerated proximal functions are defined as:

```math
\mathrm{prox}_f (v) = \arg \min_x f(x) + \frac{1}{2\theta} \Vert x - v \Vert_2^2,
```

where theta = 1 / rho. Revise prox_L2 to make it consistent with the rest of the Halide-accelerated functions.

In the L-ADMM solver code generator, call the proximal function by
converting rho to theta ahead of time.

Related to: #115 . 