### PR TITLE
Remove the Ubuntu 20.04 test environment

### DIFF
--- a/.github/workflows/compile-halide-cpp.yml
+++ b/.github/workflows/compile-halide-cpp.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-22.04, ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10"]
 
     steps:


### PR DESCRIPTION
Github Action removed the support of Ubuntu 20.04. Use Ubuntu 22.04 for continuous integration (CI) testing instead.