### PR TITLE
Experimental ProxImaL-IR: implement slicing operation

### DIFF
--- a/proximal/examples/test_proximal_lite.py
+++ b/proximal/examples/test_proximal_lite.py
@@ -1,7 +1,3 @@
-import sys
-
-sys.path.append("/home/antony/Projects/ProxImaL/")
-
 import numpy as np
 
 from proximal.experimental.codegen import LinearizedADMM
@@ -11,20 +7,36 @@ from proximal.experimental.optimize.group import group
 from proximal.experimental.optimize.scale import scale
 from proximal.experimental.optimize.split import split
 
-dims = [512, 512]
-out_dims = [128, 128]
-N = 5
+input_width = 512
+output_width = 256
+kernel_size = 5
+
+offset = (input_width - output_width) // 2
+assert offset >= 0
 
 problem = parse(
-    """
-sum_squares(conv(k, u) - b) +
+    f"""
+sum_squares(conv(k, u)[
+    {offset}:{offset + output_width}, {offset}:{offset + output_width}
+] - b) +
 1.0e-5 * group_norm(grad(u)) +
 1.0e-3 * sum_squares(grad(u)) +
 nonneg(u)
 """,
-    variable_dims=dims,
-    const_buffers={"b": np.ones(out_dims),
-                   'k': np.ones((N, N), order='F', dtype=np.float32) / (N*N)},
+    variable_dims=[input_width, input_width],
+    const_buffers={
+        "b": np.ones(
+            (output_width, output_width),
+            order="F",
+            dtype=np.float32,
+        ),
+        "k": np.ones(
+            (kernel_size, kernel_size),
+            order="F",
+            dtype=np.float32,
+        )
+        / (kernel_size * kernel_size),
+    },
 )
 
 print(

--- a/proximal/experimental/frontend.py
+++ b/proximal/experimental/frontend.py
@@ -77,28 +77,36 @@ class ProxImaLDSLVisitor(NodeVisitor):
         return visited_children[0]
 
     def visit_ScaleOffset(self, _, visited_children) -> list[LinOp]:
-        scale_op, lin_op, offset_op = visited_children
+        scale_op, lin_op_option, crop_option, offset_option = visited_children
 
-        scale = 1.0
+        # Decode scale value with default value 1.0
+        scale: float = 1.0
         if isinstance(scale_op, list):
             scale = scale_op[0][0]
 
+        # If crop operation exists, decode it.
+        crop_op: Crop | None = crop_option[0] if isinstance(crop_option, list) else None
+
+        # Decode offset value with default value 0.0
         offset: float | np.ndarray = 0.0
-        if isinstance(offset_op, list):
-            assert isinstance(offset_op[0][1], (float, np.ndarray))
-            offset = offset_op[0][1]
+        if isinstance(offset_option, list):
+            assert isinstance(offset_option[0][1], (float, np.ndarray))
+            offset = offset_option[0][1]
 
         has_scaleoffset: bool = scale != 1.0 or isinstance(offset, np.ndarray) or offset != 0.0
-        new_linop = MultiplyAdd(scale=scale, offset=offset)
-        assert isinstance(lin_op, list)
-        if isinstance(lin_op[0], Variable):
-            return [new_linop] if has_scaleoffset else []
+        scaleoffset_op = MultiplyAdd(scale=scale, offset=offset)
 
-        assert isinstance(lin_op[0][0], LinOp)
+        assert isinstance(lin_op_option, list)
+        lin_op = lin_op_option[0]
+
+        lin_ops: list[LinOp] = [] if isinstance(lin_op, Variable) else lin_op
+
+        if crop_op is not None:
+            lin_ops.append(crop_op)
         if has_scaleoffset:
-            lin_op[0].append(new_linop)
+            lin_ops.append(scaleoffset_op)
 
-        return lin_op[0]
+        return lin_ops
 
     def visit_ConstBuffer(self, node, _) -> np.ndarray:
         name = node.text
@@ -119,6 +127,16 @@ class ProxImaLDSLVisitor(NodeVisitor):
 
         return expression
 
+    def visit_CropOp(self, _, visited_children) -> LinOp:
+        _, x_range, _, y_range, _ = visited_children
+
+        return Crop(
+            left=x_range.start,
+            width=x_range.stop - x_range.start,
+            top=y_range.start,
+            height=y_range.stop - y_range.start,
+        )
+
     def visit_LinOp(self, _, visited_children) -> list[LinOp]:
         name, _, expression, _ = visited_children
 
@@ -130,6 +148,12 @@ class ProxImaLDSLVisitor(NodeVisitor):
         expression.append(lin_op)
 
         return expression
+
+    def visit_Slice(self, _, visited_children) -> slice:
+        start, _, stop = visited_children
+        if start > stop:
+            raise ValueError(f"Crop operator: expected start <= stop, found {start:d} < {stop:d}")
+        return slice(start, stop)
 
     def visit_Offset(self, _, visited_children) -> float:
         # TODO Support constant buffer
@@ -150,6 +174,9 @@ class ProxImaLDSLVisitor(NodeVisitor):
     def visit_NUMBER(self, node, _) -> float:
         return float(node.text)
 
+    def visit_INTEGER(self, node, _) -> int:
+        return int(node.text)
+
     def generic_visit(self, node, visited_children):
         """The generic visit method."""
         return visited_children or node
@@ -166,21 +193,26 @@ def parse(
     Problem         = ScaledProxFn ("+" ScaledProxFn)*
     ScaledProxFn    = (NUMBER FACTOR_OPERATOR)* ProxFn
     ProxFn          = ProxFnKey LPar ScaleOffset RPar
-    ScaleOffset     = (NUMBER FACTOR_OPERATOR)* (ConvOp / LinOp / Variable) (TERM_OPERATOR Offset)?
-    ConvOp          = "conv(" ConstBuffer "," ScaleOffset RPar
+    ScaleOffset     = (NUMBER FACTOR_OPERATOR)* (ConvOp / LinOp / Variable) CropOp? (TERM_OPERATOR Offset)?
+    ConvOp          = "conv(" ConstBuffer Comma ScaleOffset RPar
+    CropOp          = "[" Slice Comma Slice "]"
     LinOp           = LinOpKey LPar ScaleOffset RPar
     Offset          = NUMBER / ConstBuffer
+
+    Slice           = INTEGER ":" INTEGER
 
     TERM_OPERATOR   = ~"[-+]"
     FACTOR_OPERATOR = "*"
     NUMBER          = SCIENTIFIC / DECIMAL
     DECIMAL         = ~r"\d+\.?\d*"
     SCIENTIFIC      = ~r"\d+\.\d+e-?\d+"
+    INTEGER         = ~r"[1-9]\d*" / "0"
 
     ProxFnKey       = "sum_squares" / "norm1" / "group_norm" / "nonneg"
-    LinOpKey        = "grad" / "crop"
+    LinOpKey        = "grad"
     LPar            = "("
     RPar            = ")"
+    Comma           = ","
     """
         f"""ConstBuffer     = "{'"/"'.join([key for key in const_buffers])}"
 """

--- a/proximal/experimental/ir/prox_fns.py
+++ b/proximal/experimental/ir/prox_fns.py
@@ -92,7 +92,7 @@ class WeightedLeastSquares(ProxFnBase):
 
     def toLatex(self) -> str:
         alpha, beta, gamma, b = self.formatParameters()
-        return rf"{alpha} \Vert {beta} w^T v {b} \Vert_2^2 {gamma}"
+        return rf"{alpha} \Vert {beta} \mathtt{{Diag}}(w) v {b} \Vert_2^2 {gamma}"
 
 
 @dataclass

--- a/proximal/tests/test_frontend.py
+++ b/proximal/tests/test_frontend.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from proximal.experimental.frontend import parse
-from proximal.experimental.ir.lin_ops import FFTConv, MultiplyAdd
+from proximal.experimental.ir.lin_ops import Crop, FFTConv, MultiplyAdd
 
 
 def test_single_fn() -> None:
@@ -72,3 +72,48 @@ def test_conv_only() -> None:
     assert len(prox_fn.lin_ops) == 2
     assert isinstance(prox_fn.lin_ops[0], FFTConv)
     assert isinstance(prox_fn.lin_ops[-1], MultiplyAdd)
+
+
+def test_crop_only() -> None:
+    dims = [5, 5]
+    problem = parse(
+        "sum_squares(u[1:3, 2:5] - b)",
+        variable_dims=dims,
+        const_buffers={"b": np.ones(dims)},
+    )
+
+    assert len(problem.psi_fns) == 1
+
+    prox_fn = problem.psi_fns[0]
+    assert len(prox_fn.lin_ops) == 2
+    assert isinstance(prox_fn.lin_ops[1], MultiplyAdd)
+    assert isinstance(prox_fn.lin_ops[0], Crop)
+
+    crop_op = prox_fn.lin_ops[0]
+    assert crop_op.left == 1
+    assert crop_op.width == 2
+    assert crop_op.top == 2
+    assert crop_op.height == 3
+
+
+def test_masked_convolution() -> None:
+    dims = [5, 5]
+    problem = parse(
+        "sum_squares(conv(k, u)[1:3, 2:5] - b)",
+        variable_dims=dims,
+        const_buffers={"k": np.ones((3, 3)), "b": np.ones(dims)},
+    )
+
+    assert len(problem.psi_fns) == 1
+
+    prox_fn = problem.psi_fns[0]
+    assert len(prox_fn.lin_ops) == 3
+    assert isinstance(prox_fn.lin_ops[2], MultiplyAdd)
+    assert isinstance(prox_fn.lin_ops[1], Crop)
+    assert isinstance(prox_fn.lin_ops[0], FFTConv)
+
+    crop_op = prox_fn.lin_ops[1]
+    assert crop_op.left == 1
+    assert crop_op.width == 2
+    assert crop_op.top == 2
+    assert crop_op.height == 3


### PR DESCRIPTION
Implement the frontend parser to decode the image cropbox from the Numpy-style colon notation `u[0:128, 0:128]`. Avoid left-recursion error in the parsing logic (PEG) by limiting to one single crop per `ProxFn`.

Latex equation rendering for `WeightedSumSquares`: `|| w^T x ||^2 -> || Diag(w) * x ||^2`.

Demonstrate the use-case: masked deconvolution.

```math
\begin{align}
\hat u &= \arg \min_{u \in \mathbb{R}^2 }
f(u) + \sum_{j=1}^2 g_j\left( \mathbf{K}_j u \right) \\
f(u) &= I_+ ( u )  \\
g_1(v) &=  \Vert  \mathtt{Diag}(w) v - b \Vert_2^2  & \mathbf{K}_1 &= \mathcal{F}^T \mathbf{D} \mathcal{F}  \\
g_2(v) &= 10^{ -5 } \Vert  v  \Vert_{2, 1} + 0.001 \Vert v \Vert_2^2 & \mathbf{K}_2 &= \nabla  \\
\end{align}
```

References:

- https://arxiv.org/pdf/1707.06718 
- M. S. C. Almeida and M. A. T. Figueiredo, "Frame-based image deblurring with unknown boundary conditions using the alternating direction method of multipliers," 2013 IEEE International Conference on Image Processing, Melbourne, VIC, Australia, 2013, pp. 582-585, https://doi.org/10.1109/ICIP.2013.6738120